### PR TITLE
Add OpenTelemetry tracing and Jaeger service

### DIFF
--- a/src/screendrafts.api/Directory.Packages.props
+++ b/src/screendrafts.api/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="FluentAssertions" Version="8.0.1" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageVersion Include="MassTransit" Version="8.3.5" />
+    <PackageVersion Include="MassTransit" Version="8.3.6" />
     <PackageVersion Include="MassTransit.Abstractions" Version="8.3.6" />
     <PackageVersion Include="MediatR" Version="12.4.1" />
     <PackageVersion Include="MediatR.Contracts" Version="2.0.1" />
@@ -38,8 +38,15 @@
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.11.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.1" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.0.9" />
     <PackageVersion Include="Scrutor" Version="6.0.1" />

--- a/src/screendrafts.api/docker-compose.yml
+++ b/src/screendrafts.api/docker-compose.yml
@@ -52,4 +52,12 @@ services:
     restart: always
     ports:
       - 6379:6379 
+
+  screendrafts.jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: ScreenDrafts.Jaeger
+    ports:
+      - 4317:4317
+      - 4318:4318
+      - 16686:16686
   

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/GlobalUsings.cs
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using System.Reflection;
+﻿global using System.Diagnostics;
+global using System.Reflection;
 
 global using FastEndpoints;
 
@@ -38,5 +39,7 @@ global using ScreenDrafts.Web.Abstractions;
 global using ScreenDrafts.Web.Extensions;
 global using ScreenDrafts.Web.Logging;
 global using ScreenDrafts.Web.Middleware;
+global using ScreenDrafts.Web.OpenTelemetry;
 
 global using Serilog;
+global using Serilog.Context;

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/Middleware/LogContextTraceLoggingMiddleware.cs
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/Middleware/LogContextTraceLoggingMiddleware.cs
@@ -1,0 +1,15 @@
+﻿namespace ScreenDrafts.Web.Middleware;
+internal sealed class LogContextTraceLoggingMiddleware(RequestDelegate next)
+{
+  private readonly RequestDelegate _next = next;
+
+  public Task Invoke(HttpContext context)
+  {
+    string traceId = Activity.Current?.TraceId.ToString() ?? "null";
+
+    using (LogContext.PushProperty("TraceId", traceId))
+    {
+      return _next.Invoke(context);
+    }
+  }
+}

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/Middleware/MiddlewareExtensions.cs
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/Middleware/MiddlewareExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace ScreenDrafts.Web.Middleware;
+
+internal static class MiddlewareExtensions
+{
+  internal static IApplicationBuilder UseLogContextTraceLogging(this IApplicationBuilder app)
+  {
+    app.UseMiddleware<LogContextTraceLoggingMiddleware>();
+    return app;
+  }
+}

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/OpenTelemetry/DiagnosticsConfig.cs
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/OpenTelemetry/DiagnosticsConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace ScreenDrafts.Web.OpenTelemetry;
+
+public static class DiagnosticsConfig
+{
+  public const string ServiceName = "ScreenDrafts.Web";
+}

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/Program.cs
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/Program.cs
@@ -1,4 +1,6 @@
-﻿var builder = WebApplication.CreateBuilder(args);
+﻿using ScreenDrafts.Web.Middleware;
+
+var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((context, config) =>
   config.ReadFrom.Configuration(context.Configuration));
@@ -13,6 +15,7 @@ var redisConnectionString = builder.Configuration.GetConnectionStringOrThrow("Ca
 
 builder.Services.AddApplication(AssemblyReferences.ApplicationAssemblies);
 builder.Services.AddInfrastructure(
+  DiagnosticsConfig.ServiceName,
   [DraftsModule.ConfigureConsumers],
   databaseConnectionString,
   redisConnectionString);
@@ -49,6 +52,7 @@ app.MapHealthChecks("health", new HealthCheckOptions
   ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
 });
 
+app.UseLogContextTraceLogging();
 app.UseSerilogRequestLogging();
 
 app.UseExceptionHandler();

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/appsettings.Development.json
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/appsettings.Development.json
@@ -55,6 +55,7 @@
       "Application": "Screendrafts.Web"
     }
   },
+  "OTEL_EXPORTER_OTLP_ENDPOINT" :  "http://screendrafts.jaeger:4317",
   "OpenApi": {
     "Title": "ScreenDrafts API",
     "Version": "v1",

--- a/src/screendrafts.api/src/api/ScreenDrafts.Web/appsettings.json
+++ b/src/screendrafts.api/src/api/ScreenDrafts.Web/appsettings.json
@@ -33,6 +33,7 @@
       "Application": "ScreenDrafts.Web"
     }
   },
+  "OTEL_EXPORTER_OTLP_ENDPOINT" :  "",
   "OpenApi": {
     "Title": "",
     "Version": "",

--- a/src/screendrafts.api/src/common/ScreenDrafts.Common.Application/Behaviors/RequestLoggingPipelineBehavior.cs
+++ b/src/screendrafts.api/src/common/ScreenDrafts.Common.Application/Behaviors/RequestLoggingPipelineBehavior.cs
@@ -16,6 +16,9 @@ internal sealed class RequestLoggingPipelineBehavior<TRequest, TResponse>
     var moduleName = GetModuleName(typeof(TRequest).FullName!);
     var requsestName = typeof(TRequest).Name;
 
+    Activity.Current?.SetTag("request.module", moduleName);
+    Activity.Current?.SetTag("request.name", requsestName);
+
     using (LogContext.PushProperty("Module", moduleName))
     {
       BehaviorMessages.ProcessingRequest(_logger, requsestName);

--- a/src/screendrafts.api/src/common/ScreenDrafts.Common.Application/GlobalUsings.cs
+++ b/src/screendrafts.api/src/common/ScreenDrafts.Common.Application/GlobalUsings.cs
@@ -1,4 +1,5 @@
 ﻿global using System.Data.Common;
+global using System.Diagnostics;
 global using System.Reflection;
 
 global using FluentValidation;

--- a/src/screendrafts.api/src/common/ScreenDrafts.Common.Infrastructure/GlobalUsings.cs
+++ b/src/screendrafts.api/src/common/ScreenDrafts.Common.Infrastructure/GlobalUsings.cs
@@ -26,6 +26,9 @@ global using Newtonsoft.Json;
 
 global using Npgsql;
 
+global using OpenTelemetry.Resources;
+global using OpenTelemetry.Trace;
+
 global using Quartz;
 
 global using ScreenDrafts.Common.Application.Authorization;

--- a/src/screendrafts.api/src/common/ScreenDrafts.Common.Infrastructure/InfrastructureConfiguration.cs
+++ b/src/screendrafts.api/src/common/ScreenDrafts.Common.Infrastructure/InfrastructureConfiguration.cs
@@ -4,6 +4,7 @@ public static class InfrastructureConfiguration
 {
   public static IServiceCollection AddInfrastructure(
       this IServiceCollection services,
+      string serviceName,
       Action<IRegistrationConfigurator>[] moduleConfigureConsumers,
       string databaseConnectionString,
       string redisConnectionString)
@@ -55,6 +56,22 @@ public static class InfrastructureConfiguration
         cfg.ConfigureEndpoints(context);
       });
     });
+
+    services
+      .AddOpenTelemetry()
+      .ConfigureResource(resource => resource.AddService(serviceName))
+      .WithTracing(tracing =>
+      {
+        tracing
+          .AddAspNetCoreInstrumentation()
+          .AddHttpClientInstrumentation()
+          .AddEntityFrameworkCoreInstrumentation()
+          .AddRedisInstrumentation()
+          .AddNpgsql()
+          .AddSource(MassTransit.Logging.DiagnosticHeaders.DefaultListenerName);
+
+        tracing.AddOtlpExporter();
+      });
 
     return services;
   }

--- a/src/screendrafts.api/src/common/ScreenDrafts.Common.Infrastructure/ScreenDrafts.Common.Infrastructure.csproj
+++ b/src/screendrafts.api/src/common/ScreenDrafts.Common.Infrastructure/ScreenDrafts.Common.Infrastructure.csproj
@@ -11,6 +11,13 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" />
     <PackageReference Include="Quartz.Extensions.Hosting" />
     <PackageReference Include="Scrutor" />
   </ItemGroup>


### PR DESCRIPTION
Updated Directory.Packages.props to upgrade MassTransit and Newtonsoft.Json, and add OpenTelemetry packages. Added Jaeger service to docker-compose.yml. Updated GlobalUsings.cs with new usings. Added LogContextTraceLoggingMiddleware and UseLogContextTraceLogging extension method. Added DiagnosticsConfig for OpenTelemetry service name. Updated Program.cs to use new middleware and pass service name. Updated appsettings files with OTEL_EXPORTER_OTLP_ENDPOINT. Enhanced RequestLoggingPipelineBehavior with OpenTelemetry tags. Updated InfrastructureConfiguration for OpenTelemetry tracing and instrumentation. Updated ScreenDrafts.Common.Infrastructure.csproj with new package references.