### PR TITLE
feat: Add /media and /media/[id] pages (The Vault)

### DIFF
--- a/src/screendrafts.ui/src/app/media/[id]/page.tsx
+++ b/src/screendrafts.ui/src/app/media/[id]/page.tsx
@@ -1,0 +1,254 @@
+import SiteFooter from "@/components/layout/footer/site-footer";
+import SiteHeader from "@/components/layout/header/site-header";
+import { fetchMediaDetail } from "@/services/media/fetch-media-detail";
+import { DraftAppearance, MediaDetail } from "@/lib/media-dto";
+import { mediaTypeLabel } from "@/lib/media-type-display";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+
+const TMDB_IMAGE_BASE_W500 = "https://image.tmdb.org/t/p/w500";
+const TMDB_IMAGE_BASE_W1280 = "https://image.tmdb.org/t/p/w1280";
+
+type Props = { params: Promise<{ id: string }> };
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata({ params }: Props) {
+  const { id } = await params;
+  try {
+    const media = await fetchMediaDetail(id);
+    return { title: media.title };
+  } catch {
+    return { title: "Media" };
+  }
+}
+
+function posterInitials(title: string): string {
+  return title
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+export default async function MediaDetailPage({ params }: Props) {
+  const { id } = await params;
+
+  let media: MediaDetail;
+  try {
+    media = await fetchMediaDetail(id);
+  } catch {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/media" />
+
+      {/* Hero */}
+      <div className="relative bg-sd-ink overflow-hidden" style={{ minHeight: 360 }}>
+        {media.backdropPath && (
+          <img
+            src={`${TMDB_IMAGE_BASE_W1280}${media.backdropPath}`}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover opacity-25"
+          />
+        )}
+        <div className="relative px-10 py-16">
+          <p className="font-mono text-[11px] tracking-widest text-light-blue mb-3">
+            <Link href="/media" className="hover:text-white transition-colors">
+              / MEDIA
+            </Link>
+            <span className="text-white/40"> / </span>
+            <span>{media.title.toUpperCase()}</span>
+          </p>
+
+          <h1 className="font-oswald font-bold text-[64px] leading-[0.95] text-white mb-4">
+            {media.title.toUpperCase()}
+          </h1>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <span className="font-mono text-[9px] tracking-widest bg-white/20 text-white px-2 py-1 rounded-sm">
+              {mediaTypeLabel(media.mediaType)}
+            </span>
+            {media.year && (
+              <span className="font-mono text-[12px] text-white/70">{media.year}</span>
+            )}
+            {media.genres.map((g) => (
+              <span
+                key={g}
+                className="font-mono text-[9px] tracking-widest border border-white/30 text-white/60 px-2 py-1 rounded-sm"
+              >
+                {g}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Red accent bar */}
+      <div className="h-1 bg-sd-red" />
+
+      {/* Content */}
+      <div className="px-10 py-10 max-w-[1400px] mx-auto">
+        <div className="grid gap-10" style={{ gridTemplateColumns: "300px 1fr" }}>
+
+          {/* ── Sidebar ── */}
+          <div className="flex flex-col gap-6">
+            <PosterCard media={media} />
+            {media.directors.length > 0 && (
+              <CreditsCard title="DIRECTED BY" credits={media.directors} />
+            )}
+            {media.actors.length > 0 && (
+              <CreditsCard title="CAST" credits={media.actors.slice(0, 5)} />
+            )}
+          </div>
+
+          {/* ── Main column ── */}
+          <div className="flex flex-col gap-8">
+            <AppearancesSection appearances={media.draftAppearances} />
+          </div>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}
+
+// ── Poster card ───────────────────────────────────────────────────────────────
+
+function PosterCard({ media }: { media: MediaDetail }) {
+  return (
+    <div className="bg-white border-2 border-sd-ink overflow-hidden">
+      {/* Poster image */}
+      <div className="relative w-full bg-sd-ink overflow-hidden" style={{ aspectRatio: "2 / 3" }}>
+        {media.posterPath ? (
+          <img
+            src={`${TMDB_IMAGE_BASE_W500}${media.posterPath}`}
+            alt={media.title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center font-oswald font-bold text-[48px] text-white/30 select-none">
+            {posterInitials(media.title)}
+          </div>
+        )}
+      </div>
+
+      <div className="p-5 flex flex-col gap-4">
+        {/* Plot */}
+        {media.plot && (
+          <p className="font-serif text-[15px] italic leading-relaxed text-sd-ink/75">
+            {media.plot}
+          </p>
+        )}
+
+        {/* IMDb link */}
+        {media.imdbId && (
+          <a
+            href={`https://www.imdb.com/title/${media.imdbId}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-[10px] tracking-widest text-sd-blue hover:text-sd-red transition-colors"
+          >
+            VIEW ON IMDb →
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Credits card ──────────────────────────────────────────────────────────────
+
+function CreditsCard({ title, credits }: { title: string; credits: string[] }) {
+  return (
+    <div className="bg-white border-2 border-sd-ink p-5">
+      <h2 className="font-oswald font-bold text-[13px] tracking-widest text-sd-red mb-3">
+        {title}
+      </h2>
+      <div className="flex flex-col gap-1.5">
+        {credits.map((name) => (
+          <span key={name} className="font-oswald text-[15px] text-sd-ink leading-tight">
+            {name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Draft appearances ─────────────────────────────────────────────────────────
+
+function AppearancesSection({ appearances }: { appearances: DraftAppearance[] }) {
+  return (
+    <div className="bg-white border-2 border-sd-ink">
+      <div className="bg-sd-ink px-6 py-5 flex items-center gap-3">
+        <span className="block w-1 h-4 bg-sd-red shrink-0" />
+        <h2 className="font-oswald font-bold text-[13px] tracking-widest text-sd-red">
+          DRAFT APPEARANCES
+        </h2>
+        <span className="text-white/40 font-mono text-[12px]">({appearances.length})</span>
+      </div>
+
+      {appearances.length === 0 ? (
+        <div className="px-6 py-10 text-center font-mono text-[11px] text-sd-ink/40">
+          No draft appearances recorded.
+        </div>
+      ) : (
+        <div className="divide-y divide-sd-ink/5">
+          {appearances.map((a, i) => (
+            <AppearanceRow key={`${a.draftPublicId}-${i}`} appearance={a} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AppearanceRow({ appearance }: { appearance: DraftAppearance }) {
+  const { draftPublicId, draftTitle, episodeNumber, pickedBy, position, wasVetoed } = appearance;
+
+  return (
+    <div className="px-6 py-4 flex items-center gap-4">
+      {/* Position badge */}
+      <div
+        className={`w-9 h-9 shrink-0 flex items-center justify-center border-2 font-oswald font-bold text-[15px] ${
+          wasVetoed
+            ? "border-sd-ink/20 text-sd-ink/30"
+            : "border-sd-red text-sd-red"
+        }`}
+      >
+        <span className={wasVetoed ? "line-through" : ""}>{position ?? "—"}</span>
+      </div>
+
+      <div className="flex-1 min-w-0">
+        {/* Draft title */}
+        <Link
+          href={`/drafts/${draftPublicId}`}
+          className="font-oswald font-bold text-[18px] text-sd-ink leading-tight hover:text-sd-blue transition-colors"
+        >
+          {draftTitle}
+        </Link>
+
+        {/* Meta row */}
+        <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
+          <span className="font-mono text-[10px] tracking-widest text-[#5a6075]">
+            PICKED BY {pickedBy.toUpperCase()}
+          </span>
+          {episodeNumber !== null && (
+            <span className="font-mono text-[10px] tracking-widest text-[#5a6075]">
+              EP. {episodeNumber}
+            </span>
+          )}
+          {wasVetoed && (
+            <span className="font-mono text-[11px] tracking-widest text-sd-red font-bold">
+              ✕ VETOED
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/media/page.tsx
+++ b/src/screendrafts.ui/src/app/media/page.tsx
@@ -1,0 +1,176 @@
+import MediaCard from "@/components/features/media/media-card";
+import MediaFilterStrip from "@/components/features/media/media-filter-strip";
+import SiteFooter from "@/components/layout/footer/site-footer";
+import SiteHeader from "@/components/layout/header/site-header";
+import { fetchMedia } from "@/services/media/fetch-media";
+import { Metadata } from "next";
+import { Suspense } from "react";
+
+export const metadata: Metadata = {
+  title: "The Vault",
+  description: "Every film, series, and game that has ever touched a ScreenDrafts board.",
+};
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+function asNumber(v: string | string[] | undefined): number | undefined {
+  if (!v) return undefined;
+  const n = Number(Array.isArray(v) ? v[0] : v);
+  return isNaN(n) ? undefined : n;
+}
+
+function asString(v: string | string[] | undefined): string | undefined {
+  if (!v) return undefined;
+  return Array.isArray(v) ? v[0] : v;
+}
+
+export default async function MediaPage(props: { searchParams: SearchParams }) {
+  const qp = await props.searchParams;
+
+  const page = asNumber(qp.page) ?? 1;
+  const pageSize = asNumber(qp.pageSize) ?? 24;
+  const sort = asString(qp.sort) ?? "title";
+  const q = asString(qp.q);
+  const mediaType = asString(qp.mediaType) ?? "";
+
+  const result = await fetchMedia({
+    page,
+    pageSize,
+    sort,
+    search: q,
+    mediaType: mediaType || undefined,
+  });
+
+  const totalPages = Math.ceil(result.totalCount / pageSize);
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/media" />
+
+      {/* Banner */}
+      <div className="bg-sd-ink text-white" style={{ padding: "56px 40px 44px" }}>
+        <p className="font-mono text-[11px] tracking-widest text-light-blue mb-3">/ MEDIA</p>
+        <div className="flex items-end justify-between gap-8">
+          <h1 className="font-oswald font-bold text-[72px] leading-[0.95] text-white">
+            THE VAULT
+          </h1>
+          <p className="font-serif italic text-[17px] leading-relaxed text-white/70 max-w-[480px] text-right">
+            Every film, series, and game that has ever touched a ScreenDrafts board.
+          </p>
+        </div>
+      </div>
+
+      {/* Filter strip */}
+      <Suspense>
+        <MediaFilterStrip mediaType={mediaType} sort={sort} q={q} />
+      </Suspense>
+
+      {/* Grid */}
+      <div className="px-10 py-10">
+        {result.totalCount === 0 ? (
+          <div className="text-center font-mono text-sm text-sd-ink/50 py-16">
+            Nothing in the Vault yet.
+          </div>
+        ) : (
+          <div
+            className="grid gap-[22px]"
+            style={{ gridTemplateColumns: "repeat(4, 1fr)" }}
+          >
+            {result.items.map((item) => (
+              <MediaCard key={item.publicId} item={item} />
+            ))}
+          </div>
+        )}
+
+        {/* Pagination */}
+        <div className="flex items-center justify-between mt-8">
+          <span className="font-mono text-[11px] text-sd-ink/60">
+            SHOWING {result.items.length} OF {result.totalCount.toLocaleString("en-US")} TITLES
+          </span>
+          {totalPages > 1 && (
+            <Paginator page={page} totalPages={totalPages} searchParams={qp} />
+          )}
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}
+
+function Paginator({
+  page,
+  totalPages,
+  searchParams,
+}: {
+  page: number;
+  totalPages: number;
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  function pageHref(p: number): string {
+    const qs = new URLSearchParams();
+    Object.entries(searchParams).forEach(([k, v]) => {
+      if (k === "page") return;
+      if (Array.isArray(v)) v.forEach((s) => qs.append(k, s));
+      else if (v) qs.set(k, v);
+    });
+    qs.set("page", String(p));
+    return `?${qs.toString()}`;
+  }
+
+  const pages = buildPageRange(page, totalPages);
+
+  return (
+    <nav className="flex items-center gap-1 font-mono text-[11px]">
+      {page > 1 && (
+        <a
+          href={pageHref(page - 1)}
+          className="px-2.5 py-1 border border-sd-ink text-sd-ink hover:bg-sd-ink hover:text-white transition-colors"
+        >
+          ‹
+        </a>
+      )}
+      {pages.map((p, i) =>
+        p === "…" ? (
+          <span key={`ellipsis-${i}`} className="px-2 text-sd-ink/40">
+            …
+          </span>
+        ) : (
+          <a
+            key={p}
+            href={pageHref(p as number)}
+            className={`px-2.5 py-1 border transition-colors ${
+              p === page
+                ? "bg-sd-ink text-white border-sd-ink"
+                : "border-sd-ink text-sd-ink hover:bg-sd-ink hover:text-white"
+            }`}
+          >
+            {p}
+          </a>
+        )
+      )}
+      {page < totalPages && (
+        <a
+          href={pageHref(page + 1)}
+          className="px-2.5 py-1 border border-sd-ink text-sd-ink hover:bg-sd-ink hover:text-white transition-colors"
+        >
+          ›
+        </a>
+      )}
+    </nav>
+  );
+}
+
+function buildPageRange(current: number, total: number): (number | "…")[] {
+  if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+  const pages: (number | "…")[] = [1];
+  if (current > 3) pages.push("…");
+  for (let p = Math.max(2, current - 1); p <= Math.min(total - 1, current + 1); p++) {
+    pages.push(p);
+  }
+  if (current < total - 2) pages.push("…");
+  pages.push(total);
+  return pages;
+}

--- a/src/screendrafts.ui/src/components/features/media/media-card.tsx
+++ b/src/screendrafts.ui/src/components/features/media/media-card.tsx
@@ -1,0 +1,78 @@
+import { MediaListItem } from "@/lib/media-dto";
+import { mediaTypeLabel } from "@/lib/media-type-display";
+import Link from "next/link";
+
+const TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w500";
+
+function posterInitials(title: string): string {
+  return title
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+interface MediaCardProps {
+  item: MediaListItem;
+}
+
+export default function MediaCard({ item }: MediaCardProps) {
+  const { publicId, title, year, mediaType, posterPath, draftCount } = item;
+
+  return (
+    <Link
+      href={`/media/${publicId}`}
+      className="group block bg-white border-2 border-sd-ink relative transition-all duration-[140ms] hover:-translate-y-[3px] hover:shadow-[6px_6px_0_#0d1430]"
+    >
+      {/* Poster */}
+      <div className="relative w-full overflow-hidden bg-sd-ink" style={{ aspectRatio: "2 / 3" }}>
+        {posterPath ? (
+          <img
+            src={`${TMDB_IMAGE_BASE}${posterPath}`}
+            alt={title}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center font-oswald font-bold text-[40px] text-white/30 select-none">
+            {posterInitials(title)}
+          </div>
+        )}
+      </div>
+
+      <div className="p-5">
+        {/* Type badge + year */}
+        <div className="flex items-center gap-2 mb-2">
+          <span className="font-mono text-[9px] tracking-widest bg-sd-ink text-white px-1.5 py-0.5 rounded-sm">
+            {mediaTypeLabel(mediaType)}
+          </span>
+          {year && (
+            <span className="font-mono text-[10px] text-[#5a6075]">{year}</span>
+          )}
+        </div>
+
+        {/* Title */}
+        <div className="font-oswald font-bold text-[20px] text-sd-ink leading-tight mb-3">
+          {title}
+        </div>
+
+        {/* Stat */}
+        <div className="border-t border-sd-ink/10 pt-3 mt-3">
+          <StatCell value={draftCount} label="APPEARANCES" />
+        </div>
+
+        <div className="mt-4 font-oswald font-semibold text-[12px] tracking-wide text-sd-blue group-hover:text-sd-red transition-colors">
+          VIEW DETAILS →
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function StatCell({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span className="font-oswald font-bold text-[28px] text-sd-ink leading-none">{value}</span>
+      <span className="font-mono text-[9px] text-[#5a6075] text-center">{label}</span>
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/components/features/media/media-filter-strip.tsx
+++ b/src/screendrafts.ui/src/components/features/media/media-filter-strip.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import MediaTypeTabs from "./media-type-tabs";
+
+interface MediaFilterStripProps {
+  mediaType: string;
+  sort: string;
+  q?: string;
+}
+
+const SORT_OPTIONS = [
+  { value: "title",       label: "Title A–Z" },
+  { value: "appearances", label: "Most Appearances" },
+  { value: "year",        label: "Year" },
+];
+
+export default function MediaFilterStrip({ mediaType, sort, q }: MediaFilterStripProps) {
+  function sortHref(value: string) {
+    const qs = new URLSearchParams({ sort: value, page: "1" });
+    if (mediaType) qs.set("mediaType", mediaType);
+    if (q) qs.set("q", q);
+    return `?${qs.toString()}`;
+  }
+
+  return (
+    <div className="bg-white border-b border-sd-ink/20 px-10 py-4 flex items-center justify-between gap-6">
+      {/* Media type tabs — client component */}
+      <MediaTypeTabs mediaType={mediaType} sort={sort} q={q} />
+
+      <div className="flex items-center gap-4">
+        {/* Search */}
+        <form method="get" action="">
+          <input type="hidden" name="sort" value={sort} />
+          <input type="hidden" name="page" value="1" />
+          {mediaType && <input type="hidden" name="mediaType" value={mediaType} />}
+          <input
+            name="q"
+            defaultValue={q ?? ""}
+            placeholder="Search…"
+            className="border border-sd-ink/30 px-3 py-1.5 font-mono text-[11px] text-sd-ink placeholder:text-sd-ink/40 focus:outline-none focus:border-sd-ink w-40"
+          />
+        </form>
+
+        {/* Sort */}
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] tracking-widest text-sd-blue shrink-0">
+            SORT BY
+          </span>
+          <div className="flex gap-1">
+            {SORT_OPTIONS.map((opt) => (
+              <Link
+                key={opt.value}
+                href={sortHref(opt.value)}
+                className={`px-3 py-1.5 font-mono text-[11px] transition-colors border ${
+                  sort === opt.value
+                    ? "bg-sd-ink text-white border-sd-ink"
+                    : "border-sd-ink/30 text-sd-ink hover:border-sd-ink"
+                }`}
+              >
+                {opt.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/components/features/media/media-type-tabs.tsx
+++ b/src/screendrafts.ui/src/components/features/media/media-type-tabs.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+const TABS = [
+  { value: "",          label: "ALL" },
+  { value: "Movie",     label: "MOVIES" },
+  { value: "TvShow",    label: "TV" },
+  { value: "VideoGame", label: "GAMES" },
+];
+
+interface MediaTypeTabsProps {
+  mediaType: string;
+  sort: string;
+  q?: string;
+}
+
+export default function MediaTypeTabs({ mediaType, sort, q }: MediaTypeTabsProps) {
+  const router = useRouter();
+
+  function handleTab(value: string) {
+    const qs = new URLSearchParams({ sort, page: "1" });
+    if (value) qs.set("mediaType", value);
+    if (q) qs.set("q", q);
+    router.push(`?${qs.toString()}`);
+  }
+
+  return (
+    <div className="flex gap-1">
+      {TABS.map((tab) => (
+        <button
+          key={tab.value}
+          onClick={() => handleTab(tab.value)}
+          className={`px-4 py-2 font-oswald text-[12px] tracking-wide transition-colors ${
+            mediaType === tab.value
+              ? "bg-sd-ink text-white"
+              : "text-sd-ink hover:bg-sd-ink/5"
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/lib/media-dto.ts
+++ b/src/screendrafts.ui/src/lib/media-dto.ts
@@ -1,0 +1,35 @@
+export interface MediaListItem {
+  publicId: string;
+  title: string;
+  year: number | null;
+  mediaType: string;
+  posterPath: string | null;
+  imdbId: string | null;
+  tmdbId: number | null;
+  draftCount: number;
+}
+
+export interface DraftAppearance {
+  draftPublicId: string;
+  draftTitle: string;
+  episodeNumber: number | null;
+  pickedBy: string;
+  position: number | null;
+  wasVetoed: boolean;
+}
+
+export interface MediaDetail extends MediaListItem {
+  backdropPath: string | null;
+  plot: string | null;
+  genres: string[];
+  directors: string[];
+  actors: string[];
+  draftAppearances: DraftAppearance[];
+}
+
+export interface MediaPagedResult {
+  items: MediaListItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}

--- a/src/screendrafts.ui/src/lib/media-type-display.ts
+++ b/src/screendrafts.ui/src/lib/media-type-display.ts
@@ -1,0 +1,10 @@
+const MEDIA_TYPE_LABELS: Record<string, string> = {
+  Movie: "Movie",
+  TvShow: "TV Show",
+  TvEpisode: "TV Episode",
+  VideoGame: "Video Game",
+};
+
+export function mediaTypeLabel(mediaType: string): string {
+  return MEDIA_TYPE_LABELS[mediaType] ?? mediaType;
+}

--- a/src/screendrafts.ui/src/services/media/fetch-media-detail.ts
+++ b/src/screendrafts.ui/src/services/media/fetch-media-detail.ts
@@ -1,0 +1,33 @@
+import { auth } from "@/auth";
+import { env } from "@/lib/env";
+import { MediaDetail } from "@/lib/media-dto";
+
+const apiBase = env.apiUrl;
+
+async function authHeaders(): Promise<HeadersInit> {
+  const session = await auth();
+  if (session?.accessToken) {
+    return { Authorization: `Bearer ${session.accessToken}` };
+  }
+  return {};
+}
+
+export async function fetchMediaDetail(publicId: string): Promise<MediaDetail> {
+  const url = `${apiBase}/media/${publicId}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: await authHeaders(),
+    credentials: "include",
+    next: { revalidate: 0 },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Request failed with status ${response.status}: ${response.statusText} - ${body}`
+    );
+  }
+
+  return response.json() as Promise<MediaDetail>;
+}

--- a/src/screendrafts.ui/src/services/media/fetch-media.ts
+++ b/src/screendrafts.ui/src/services/media/fetch-media.ts
@@ -1,0 +1,44 @@
+import { auth } from "@/auth";
+import { env } from "@/lib/env";
+import { MediaPagedResult } from "@/lib/media-dto";
+
+const apiBase = env.apiUrl;
+
+async function authHeaders(): Promise<HeadersInit> {
+  const session = await auth();
+  if (session?.accessToken) {
+    return { Authorization: `Bearer ${session.accessToken}` };
+  }
+  return {};
+}
+
+export async function fetchMedia(params: {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  mediaType?: string;
+  sort?: string;
+} = {}): Promise<MediaPagedResult> {
+  const url = new URL(`${apiBase}/media`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== "") {
+      url.searchParams.set(key, String(value));
+    }
+  });
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: await authHeaders(),
+    credentials: "include",
+    next: { revalidate: 0 },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Request failed with status ${response.status}: ${response.statusText} - ${body}`
+    );
+  }
+
+  return response.json() as Promise<MediaPagedResult>;
+}


### PR DESCRIPTION
## Summary

- Adds **The Vault** — the media browsing section of the ScreenDrafts UI — at `/media` and `/media/[id]`, following the structural and visual conventions of `/drafters` and `/drafters/[id]`
- All new components; no existing files modified

## What changed

### Types & utilities
- `src/lib/media-dto.ts` — `MediaListItem`, `MediaDetail`, `DraftAppearance`, `MediaPagedResult` interfaces typed against the `/media` and `/media/{publicId}` API contracts
- `src/lib/media-type-display.ts` — `mediaTypeLabel()` label map (`Movie`, `TvShow → "TV Show"`, `TvEpisode → "TV Episode"`, `VideoGame → "Video Game"`)

### Services
- `src/services/media/fetch-media.ts` — `fetchMedia()` with `page`, `pageSize`, `search`, `mediaType`, `sort` params; same auth-header + `force-dynamic` pattern as `fetch-participants.ts`
- `src/services/media/fetch-media-detail.ts` — `fetchMediaDetail(publicId)`; throws on non-OK so the page can call `notFound()` on 404

### Components
- `MediaCard` — poster (TMDb `w500` URL, or initials in dark rectangle fallback), type badge + year, Oswald title, `StatCell` APPEARANCES stat, hover lift/shadow matching `ParticipantCard`
- `MediaTypeTabs` (client) — `useRouter`-based tab switcher: All / Movies / TV / Games
- `MediaFilterStrip` (server) — wraps `MediaTypeTabs`, search `<form>`, and sort `<Link>` buttons; mirrors `DraftersFilterStrip` layout

### Pages
- `/media` — `force-dynamic` server component; `sd-ink` banner "THE VAULT" + editorial subtitle; 4-column `MediaCard` grid; "Nothing in the Vault yet." empty state; pagination identical to `/drafters`
- `/media/[id]` — `force-dynamic` server component; backdrop hero (TMDb `w1280`) with dark overlay, overlaid title, year, genre chips; two-column layout (300 px sidebar: poster + plot in Source Serif 4 italic + directors + cast ≤5 + IMDb link; main column: DRAFT APPEARANCES table with red accent bar header, position badge, `VETOED` in `sd-red`); `notFound()` on fetch error

## Test plan

- [ ] `/media` renders the grid and shows "Nothing in the Vault yet." when API returns `totalCount: 0`
- [ ] Media type tabs filter correctly; sort links preserve other query params
- [ ] Search form submits and filters results
- [ ] Pagination appears when `totalPages > 1` and preserves filter/sort params
- [ ] `/media/[id]` renders hero backdrop, sidebar poster, plot, directors, cast, IMDb link
- [ ] Vetoed appearances show strikethrough position badge and "✕ VETOED" in red
- [ ] Non-existent `publicId` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)