### PR TITLE
feat(ui): add /profile and /admin pages

### DIFF
--- a/src/screendrafts.ui/src/app/admin/manage-roles-panel.tsx
+++ b/src/screendrafts.ui/src/app/admin/manage-roles-panel.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState } from "react";
+import { AdminUserItem, AdminRoleItem } from "@/services/admin/fetch-admin";
+
+interface ManageRolesPanelProps {
+  user: AdminUserItem;
+  allRoles: AdminRoleItem[];
+  accessToken: string | undefined;
+  apiBase: string;
+  onClose: () => void;
+  onRolesChanged: (userId: string, roles: string[]) => void;
+}
+
+export default function ManageRolesPanel({
+  user,
+  allRoles,
+  accessToken,
+  apiBase,
+  onClose,
+  onRolesChanged,
+}: ManageRolesPanelProps) {
+  const [roles, setRoles] = useState<string[]>(user.roles);
+  const [selectedRole, setSelectedRole] = useState('');
+  const [toast, setToast] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const available = allRoles.filter(r => !roles.includes(r.name));
+  const headers = accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+
+  function showToast(type: 'success' | 'error', message: string) {
+    setToast({ type, message });
+    setTimeout(() => setToast(null), 3000);
+  }
+
+  async function addRole() {
+    if (!selectedRole || busy) return;
+    const prev = roles;
+    setRoles(r => [...r, selectedRole]);
+    setSelectedRole('');
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `${apiBase}/admin/roles/${encodeURIComponent(selectedRole)}/users/${encodeURIComponent(user.publicId)}`,
+        { method: 'POST', headers }
+      );
+      if (!res.ok) throw new Error(`${res.status}`);
+      onRolesChanged(user.publicId, [...prev, selectedRole]);
+      showToast('success', `Added role "${selectedRole}".`);
+    } catch {
+      setRoles(prev);
+      showToast('error', `Failed to add role "${selectedRole}".`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeRole(roleName: string) {
+    if (busy) return;
+    const prev = roles;
+    setRoles(r => r.filter(x => x !== roleName));
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `${apiBase}/admin/roles/${encodeURIComponent(roleName)}/users/${encodeURIComponent(user.publicId)}`,
+        { method: 'DELETE', headers }
+      );
+      if (!res.ok) throw new Error(`${res.status}`);
+      onRolesChanged(user.publicId, prev.filter(x => x !== roleName));
+      showToast('success', `Removed role "${roleName}".`);
+    } catch {
+      setRoles(prev);
+      showToast('error', `Failed to remove role "${roleName}".`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-sd-ink/30 z-40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <aside className="fixed right-0 top-0 bottom-0 w-[420px] bg-sd-paper border-l border-sd-ink z-50 flex flex-col shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-5 border-b border-sd-ink/10 bg-sd-ink">
+          <div>
+            <p className="font-oswald font-bold text-[18px] text-white leading-tight">{user.displayName}</p>
+            <p className="font-mono text-[11px] text-light-blue mt-0.5">{user.email}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/60 hover:text-white text-[24px] leading-none"
+            aria-label="Close panel"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-6 space-y-7">
+          {/* Current roles */}
+          <section>
+            <p className="font-mono text-[10px] tracking-widest text-sd-ink/50 uppercase mb-3">Current Roles</p>
+            {roles.length === 0 ? (
+              <p className="text-[13px] text-sd-ink/40 italic">No roles assigned.</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {roles.map(role => (
+                  <span
+                    key={role}
+                    className={`inline-flex items-center gap-1.5 font-mono text-xs px-2.5 py-1 rounded-full text-white ${
+                      role.toLowerCase().includes('admin') ? 'bg-sd-red' : 'bg-sd-blue'
+                    }`}
+                  >
+                    {role}
+                    <button
+                      onClick={() => removeRole(role)}
+                      disabled={busy}
+                      className="leading-none opacity-70 hover:opacity-100 text-[14px]"
+                      aria-label={`Remove ${role}`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* Add role */}
+          <section>
+            <p className="font-mono text-[10px] tracking-widest text-sd-ink/50 uppercase mb-3">Add Role</p>
+            <div className="flex gap-2">
+              <select
+                value={selectedRole}
+                onChange={e => setSelectedRole(e.target.value)}
+                className="flex-1 border border-sd-ink/20 bg-sd-paper px-3 py-2 text-sd-ink text-sm focus:outline-none focus:ring-2 focus:ring-sd-blue rounded"
+              >
+                <option value="">Select a role…</option>
+                {available.map(r => (
+                  <option key={r.name} value={r.name}>{r.name}</option>
+                ))}
+              </select>
+              <button
+                onClick={addRole}
+                disabled={!selectedRole || busy}
+                className="bg-sd-blue text-white font-oswald tracking-wide uppercase px-4 py-2 hover:bg-sd-blue/90 disabled:opacity-40 transition-colors rounded"
+              >
+                ADD
+              </button>
+            </div>
+          </section>
+        </div>
+
+        {/* Toast */}
+        {toast && (
+          <div className={`px-6 py-3 text-[13px] font-mono ${toast.type === 'success' ? 'bg-green-100 text-green-800' : 'bg-red-50 text-sd-red'}`}>
+            {toast.message}
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/page.tsx
+++ b/src/screendrafts.ui/src/app/admin/page.tsx
@@ -1,0 +1,80 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { fetchAdminUsers, fetchAdminRoles } from "@/services/admin/fetch-admin";
+import SiteHeader from "@/components/layout/header/site-header";
+import SiteFooter from "@/components/layout/footer/site-footer";
+import UserTable from "./user-table";
+import PasswordResetCard from "./password-reset-card";
+import RolesAccordion from "./roles-accordion";
+import { Metadata } from "next";
+import { env } from "@/lib/env";
+
+export const metadata: Metadata = { title: "Administration" };
+export const dynamic = "force-dynamic";
+
+interface AdminCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function AdminCard({ title, children }: AdminCardProps) {
+  return (
+    <div className="bg-white border border-sd-ink/10">
+      <div className="flex items-center gap-3 px-6 py-4 border-b border-sd-ink/10 bg-sd-ink">
+        <div className="w-1 h-5 bg-sd-red shrink-0" />
+        <h2 className="font-oswald font-bold text-[16px] tracking-wide uppercase text-white">{title}</h2>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  );
+}
+
+export default async function AdminPage() {
+  const session = await auth();
+  if (!session?.roles?.includes('admin')) redirect('/');
+
+  const apiBase = env.apiUrl ?? '';
+  const [users, roles] = await Promise.all([
+    fetchAdminUsers(),
+    fetchAdminRoles(),
+  ]);
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/admin" />
+
+      <div className="px-6 md:px-10 py-10 max-w-[1200px] mx-auto">
+        <p className="font-mono text-[11px] tracking-widest text-sd-ink/50 mb-6">/ ADMIN</p>
+        <h1 className="font-oswald font-bold text-[56px] leading-none text-sd-ink mb-10">
+          ADMINISTRATION
+        </h1>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* User Management */}
+          <div className="lg:col-span-2">
+            <AdminCard title="Users">
+              <UserTable
+                initialUsers={users}
+                allRoles={roles}
+                accessToken={session.accessToken}
+                apiBase={apiBase}
+              />
+            </AdminCard>
+          </div>
+
+          {/* Password Reset */}
+          <AdminCard title="Reset User Password">
+            <PasswordResetCard accessToken={session.accessToken} apiBase={apiBase} />
+          </AdminCard>
+
+          {/* Roles Reference */}
+          <AdminCard title="Roles & Permissions">
+            <RolesAccordion roles={roles} accessToken={session.accessToken} apiBase={apiBase} />
+          </AdminCard>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/password-reset-card.tsx
+++ b/src/screendrafts.ui/src/app/admin/password-reset-card.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState, useEffect, useRef } from "react";
+import { AdminUserItem } from "@/services/admin/fetch-admin";
+
+interface PasswordResetCardProps {
+  accessToken: string | undefined;
+  apiBase: string;
+}
+
+export default function PasswordResetCard({ accessToken, apiBase }: PasswordResetCardProps) {
+  const [search, setSearch] = useState('');
+  const [results, setResults] = useState<AdminUserItem[]>([]);
+  const [selected, setSelected] = useState<AdminUserItem | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!search.trim()) { setResults([]); return; }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const url = new URL(`${apiBase}/admin/users`);
+        url.searchParams.set('search', search);
+        const res = await fetch(url.toString(), {
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+        });
+        if (res.ok) setResults(await res.json() as AdminUserItem[]);
+      } catch {
+        // ignore
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [search, accessToken, apiBase]);
+
+  function selectUser(user: AdminUserItem) {
+    setSelected(user);
+    setSearch('');
+    setResults([]);
+    setStatus(null);
+  }
+
+  async function sendReset() {
+    if (!selected || sending) return;
+    setSending(true);
+    setStatus(null);
+    try {
+      const res = await fetch(
+        `${apiBase}/admin/users/${encodeURIComponent(selected.publicId)}/password-reset`,
+        {
+          method: 'POST',
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+        }
+      );
+      if (!res.ok) throw new Error(`${res.status}`);
+      setStatus({ type: 'success', message: `Reset email sent to ${selected.email}.` });
+    } catch {
+      setStatus({ type: 'error', message: 'Failed to send reset email. Please try again.' });
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      {!selected ? (
+        <div className="relative">
+          <label className="block font-mono text-[10px] tracking-widest text-sd-ink/50 uppercase mb-1">
+            Find User by Name or Email
+          </label>
+          <input
+            type="search"
+            value={search}
+            onChange={e => { setSearch(e.target.value); setSelected(null); setStatus(null); }}
+            placeholder="Search…"
+            className="border border-sd-ink/20 bg-sd-paper px-3 py-2 text-sd-ink text-sm focus:outline-none focus:ring-2 focus:ring-sd-blue rounded w-full"
+          />
+          {(results.length > 0 || searching) && (
+            <div className="absolute left-0 right-0 top-full mt-1 bg-white border border-sd-ink/20 shadow-lg z-10 max-h-[200px] overflow-y-auto">
+              {searching && (
+                <p className="px-4 py-2 text-[12px] text-sd-ink/40 italic">Searching…</p>
+              )}
+              {results.map(user => (
+                <button
+                  key={user.publicId}
+                  onClick={() => selectUser(user)}
+                  className="w-full text-left px-4 py-2.5 hover:bg-sd-paper border-b border-sd-ink/5 last:border-0 transition-colors"
+                >
+                  <p className="text-[13px] font-medium text-sd-ink">{user.displayName}</p>
+                  <p className="font-mono text-[11px] text-sd-ink/50">{user.email}</p>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between p-4 border border-sd-ink/10 bg-sd-paper/50">
+            <div>
+              <p className="font-medium text-sd-ink">{selected.displayName}</p>
+              <p className="font-mono text-[12px] text-sd-ink/50">{selected.email}</p>
+            </div>
+            <button
+              onClick={() => { setSelected(null); setStatus(null); }}
+              className="text-[12px] font-mono text-sd-ink/40 hover:text-sd-ink underline"
+            >
+              change
+            </button>
+          </div>
+          <button
+            onClick={sendReset}
+            disabled={sending}
+            className="bg-sd-red text-white font-oswald tracking-wide uppercase px-4 py-2 hover:bg-sd-red/90 disabled:opacity-50 transition-colors"
+          >
+            {sending ? 'SENDING…' : 'SEND PASSWORD RESET EMAIL'}
+          </button>
+        </div>
+      )}
+
+      {status && (
+        <p className={`text-[13px] ${status.type === 'success' ? 'text-green-700' : 'text-sd-red'}`}>
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/roles-accordion.tsx
+++ b/src/screendrafts.ui/src/app/admin/roles-accordion.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from "react";
+import { AdminRoleItem } from "@/services/admin/fetch-admin";
+
+interface RolesAccordionProps {
+  roles: AdminRoleItem[];
+  accessToken: string | undefined;
+  apiBase: string;
+}
+
+interface RoleRowProps {
+  role: AdminRoleItem;
+  accessToken: string | undefined;
+  apiBase: string;
+}
+
+function RoleRow({ role, accessToken, apiBase }: RoleRowProps) {
+  const [open, setOpen] = useState(false);
+  const [permissions, setPermissions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  async function toggle() {
+    if (!open && !loaded) {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          `${apiBase}/admin/roles/${encodeURIComponent(role.name)}/permissions`,
+          {
+            headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+          }
+        );
+        if (res.ok) {
+          const data = await res.json() as { permissions?: string[] };
+          setPermissions(data.permissions ?? []);
+        }
+        setLoaded(true);
+      } catch {
+        setLoaded(true);
+      } finally {
+        setLoading(false);
+      }
+    }
+    setOpen(o => !o);
+  }
+
+  const isAdmin = role.name.toLowerCase().includes('admin');
+
+  return (
+    <div className="border-b border-sd-ink/10 last:border-0">
+      <button
+        onClick={toggle}
+        className="w-full flex items-center justify-between px-4 py-3.5 hover:bg-sd-paper/60 transition-colors text-left"
+      >
+        <div className="flex items-center gap-3">
+          <span className={`font-mono text-xs px-2 py-0.5 rounded-full text-white ${isAdmin ? 'bg-sd-red' : 'bg-sd-blue'}`}>
+            {role.name}
+          </span>
+          {role.description && (
+            <span className="text-[12px] text-sd-ink/50">{role.description}</span>
+          )}
+        </div>
+        <span className="text-sd-ink/40 text-[18px] leading-none select-none">{open ? '−' : '+'}</span>
+      </button>
+
+      {open && (
+        <div className="px-4 pb-4">
+          {loading ? (
+            <p className="text-[12px] text-sd-ink/40 italic">Loading permissions…</p>
+          ) : permissions.length === 0 ? (
+            <p className="text-[12px] text-sd-ink/40 italic">No permissions defined for this role.</p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {permissions.map(perm => (
+                <span key={perm} className="font-mono text-[11px] px-2 py-0.5 bg-sd-ink/5 border border-sd-ink/15 text-sd-ink rounded">
+                  {perm}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function RolesAccordion({ roles, accessToken, apiBase }: RolesAccordionProps) {
+  if (roles.length === 0) {
+    return <p className="text-[13px] text-sd-ink/40 italic">No roles defined.</p>;
+  }
+
+  return (
+    <div className="border border-sd-ink/15 divide-y divide-sd-ink/10">
+      {roles.map(role => (
+        <RoleRow key={role.name} role={role} accessToken={accessToken} apiBase={apiBase} />
+      ))}
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/user-table.tsx
+++ b/src/screendrafts.ui/src/app/admin/user-table.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState, useEffect, useRef } from "react";
+import { AdminUserItem, AdminRoleItem } from "@/services/admin/fetch-admin";
+import ManageRolesPanel from "./manage-roles-panel";
+
+interface UserTableProps {
+  initialUsers: AdminUserItem[];
+  allRoles: AdminRoleItem[];
+  accessToken: string | undefined;
+  apiBase: string;
+}
+
+function RoleBadge({ role }: { role: string }) {
+  const isAdmin = role.toLowerCase().includes('admin');
+  return (
+    <span className={`font-mono text-xs px-2 py-0.5 rounded-full text-white ${isAdmin ? 'bg-sd-red' : 'bg-sd-blue'}`}>
+      {role}
+    </span>
+  );
+}
+
+export default function UserTable({ initialUsers, allRoles, accessToken, apiBase }: UserTableProps) {
+  const [users, setUsers] = useState<AdminUserItem[]>(initialUsers);
+  const [search, setSearch] = useState('');
+  const [searching, setSearching] = useState(false);
+  const [managingUser, setManagingUser] = useState<AdminUserItem | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!search.trim()) {
+      setUsers(initialUsers);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const url = new URL(`${apiBase}/admin/users`);
+        url.searchParams.set('search', search);
+        const res = await fetch(url.toString(), {
+          headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+        });
+        if (res.ok) {
+          const data = await res.json() as AdminUserItem[];
+          setUsers(data);
+        }
+      } catch {
+        // keep current results on error
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [search, initialUsers, accessToken, apiBase]);
+
+  function handleRolesChanged(userId: string, newRoles: string[]) {
+    setUsers(prev => prev.map(u => u.publicId === userId ? { ...u, roles: newRoles } : u));
+  }
+
+  return (
+    <>
+      {/* Search */}
+      <div className="flex items-center justify-between mb-3">
+        <p className="font-mono text-[10px] tracking-widest text-sd-ink/50 uppercase">
+          {searching ? 'Searching…' : `${users.length} users`}
+        </p>
+        <input
+          type="search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search users…"
+          className="border border-sd-ink/20 bg-sd-paper px-3 py-1.5 text-sd-ink text-sm focus:outline-none focus:ring-2 focus:ring-sd-blue rounded w-[220px]"
+        />
+      </div>
+
+      {/* Table */}
+      <div className="border border-sd-ink/20 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-sd-ink text-white">
+              <th className="text-left px-4 py-3 font-mono text-[10px] tracking-widest uppercase">Display Name</th>
+              <th className="text-left px-4 py-3 font-mono text-[10px] tracking-widest uppercase">Email</th>
+              <th className="text-left px-4 py-3 font-mono text-[10px] tracking-widest uppercase">Roles</th>
+              <th className="px-4 py-3 font-mono text-[10px] tracking-widest uppercase text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-sd-ink/40 text-[13px] italic">
+                  No users found.
+                </td>
+              </tr>
+            ) : (
+              users.map((user, i) => (
+                <tr
+                  key={user.publicId}
+                  className={`border-t border-sd-ink/10 hover:bg-sd-paper transition-colors ${i % 2 === 1 ? 'bg-sd-ink/[0.02]' : 'bg-white'}`}
+                >
+                  <td className="px-4 py-3 font-medium text-sd-ink">{user.displayName}</td>
+                  <td className="px-4 py-3 font-mono text-[12px] text-sd-ink/70">{user.email}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {user.roles.map(r => <RoleBadge key={r} role={r} />)}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => setManagingUser(user)}
+                      className="border border-sd-ink text-sd-ink font-oswald tracking-wide uppercase text-[11px] px-3 py-1.5 hover:bg-sd-ink hover:text-sd-paper transition-colors"
+                    >
+                      Manage Roles ›
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {managingUser && (
+        <ManageRolesPanel
+          user={managingUser}
+          allRoles={allRoles}
+          accessToken={accessToken}
+          apiBase={apiBase}
+          onClose={() => setManagingUser(null)}
+          onRolesChanged={handleRolesChanged}
+        />
+      )}
+    </>
+  );
+}

--- a/src/screendrafts.ui/src/app/profile/avatar-upload.tsx
+++ b/src/screendrafts.ui/src/app/profile/avatar-upload.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useRef, useState } from "react";
+
+interface AvatarUploadProps {
+  currentAvatarUrl: string | null | undefined;
+  displayName: string;
+  accessToken: string | undefined;
+  apiBase: string;
+}
+
+function Initials({ name }: { name: string }) {
+  const parts = name.trim().split(/\s+/);
+  const letters = parts.length >= 2
+    ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+    : name.slice(0, 2).toUpperCase();
+  return (
+    <div className="w-[120px] h-[120px] rounded-full bg-sd-blue flex items-center justify-center">
+      <span className="font-oswald font-bold text-[36px] text-white leading-none">{letters}</span>
+    </div>
+  );
+}
+
+export default function AvatarUpload({ currentAvatarUrl, displayName, accessToken, apiBase }: AvatarUploadProps) {
+  const [avatarUrl, setAvatarUrl] = useState(currentAvatarUrl);
+  const [status, setStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  async function handleUpload() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) return;
+
+    if (file.size > 2 * 1024 * 1024) {
+      setStatus('error');
+      setErrorMsg('File must be under 2MB.');
+      return;
+    }
+
+    setStatus('uploading');
+    setErrorMsg('');
+    try {
+      const form = new FormData();
+      form.append('avatar', file);
+      const res = await fetch(`${apiBase}/users/profile/avatar`, {
+        method: 'POST',
+        headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+        body: form,
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      const data = await res.json() as { avatarUrl?: string };
+      if (data.avatarUrl) setAvatarUrl(data.avatarUrl);
+      setStatus('success');
+    } catch (err) {
+      console.error('[AvatarUpload]', err);
+      setStatus('error');
+      setErrorMsg('Upload failed. Please try again.');
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex justify-center">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={displayName}
+            className="w-[120px] h-[120px] rounded-full object-cover border border-sd-ink/20"
+          />
+        ) : (
+          <Initials name={displayName} />
+        )}
+      </div>
+
+      <p className="text-[12px] text-sd-ink/50 text-center">
+        Profile pictures are stored and served from the ScreenDrafts CDN.
+      </p>
+
+      <div className="space-y-3">
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".jpg,.jpeg,.png,.webp"
+          className="block w-full text-sm text-sd-ink/60 file:mr-3 file:py-1.5 file:px-3 file:border file:border-sd-ink/30 file:bg-sd-paper file:text-sd-ink file:text-sm file:font-mono cursor-pointer"
+        />
+        <button
+          onClick={handleUpload}
+          disabled={status === 'uploading'}
+          className="w-full bg-sd-red text-white font-oswald tracking-wide uppercase px-4 py-2 hover:bg-sd-red/90 disabled:opacity-50 transition-colors"
+        >
+          {status === 'uploading' ? 'UPLOADING…' : 'UPLOAD AVATAR'}
+        </button>
+      </div>
+
+      {status === 'success' && (
+        <p className="text-[13px] text-green-700">Avatar updated successfully.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-[13px] text-sd-red">{errorMsg}</p>
+      )}
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/profile/page.tsx
+++ b/src/screendrafts.ui/src/app/profile/page.tsx
@@ -1,0 +1,100 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { fetchProfile } from "@/services/profile/fetch-profile";
+import SiteHeader from "@/components/layout/header/site-header";
+import SiteFooter from "@/components/layout/footer/site-footer";
+import ProfileForm from "./profile-form";
+import { Metadata } from "next";
+import { env } from "@/lib/env";
+
+export const metadata: Metadata = { title: "Profile" };
+export const dynamic = "force-dynamic";
+
+function InitialsAvatar({ name }: { name: string }) {
+  const parts = name.trim().split(/\s+/);
+  const letters = parts.length >= 2
+    ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+    : name.slice(0, 2).toUpperCase();
+  return (
+    <div className="w-[100px] h-[100px] rounded-full bg-sd-blue flex items-center justify-center">
+      <span className="font-oswald font-bold text-[30px] text-white leading-none">{letters}</span>
+    </div>
+  );
+}
+
+export default async function ProfilePage() {
+  const session = await auth();
+  if (!session) redirect("/api/auth/signin?callbackUrl=/profile");
+
+  const profile = await fetchProfile();
+  const displayName = [profile?.firstName, profile?.lastName].filter(Boolean).join(' ')
+    || session.user?.name
+    || 'User';
+  const email = profile?.email || session.user?.email || '';
+  const apiBase = env.apiUrl ?? '';
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/profile" />
+
+      <div className="px-6 md:px-10 py-10 max-w-[1100px] mx-auto">
+        <p className="font-mono text-[11px] tracking-widest text-sd-ink/50 mb-6">/ PROFILE</p>
+        <h1 className="font-oswald font-bold text-[48px] leading-none text-sd-ink mb-10">
+          YOUR PROFILE
+        </h1>
+
+        <div className="flex flex-col md:flex-row gap-8">
+          {/* Sidebar */}
+          <aside className="md:w-[260px] shrink-0">
+            <div className="bg-white border border-sd-ink/10 p-6 space-y-5">
+              <div className="flex justify-center">
+                {profile?.profilePicturePath ? (
+                  <img
+                    src={profile.profilePicturePath}
+                    alt={displayName}
+                    className="w-[100px] h-[100px] rounded-full object-cover border border-sd-ink/20"
+                  />
+                ) : (
+                  <InitialsAvatar name={displayName} />
+                )}
+              </div>
+              <div className="text-center space-y-1">
+                <p className="font-oswald font-bold text-[20px] text-sd-ink leading-tight">
+                  {displayName}
+                </p>
+                {email && (
+                  <p className="font-mono text-[11px] text-sd-ink/50 break-all">{email}</p>
+                )}
+              </div>
+              <div className="border-t border-sd-ink/10 pt-4 space-y-1">
+                {profile?.twitterHandle && (
+                  <p className="font-mono text-[11px] text-sd-ink/60">𝕏 @{profile.twitterHandle}</p>
+                )}
+                {profile?.instagramHandle && (
+                  <p className="font-mono text-[11px] text-sd-ink/60">IG @{profile.instagramHandle}</p>
+                )}
+                {profile?.letterboxdHandle && (
+                  <p className="font-mono text-[11px] text-sd-ink/60">LB {profile.letterboxdHandle}</p>
+                )}
+                {profile?.blueskyHandle && (
+                  <p className="font-mono text-[11px] text-sd-ink/60">BSky {profile.blueskyHandle}</p>
+                )}
+              </div>
+            </div>
+          </aside>
+
+          {/* Main content */}
+          <main className="flex-1">
+            <ProfileForm
+              profile={profile}
+              accessToken={session.accessToken}
+              apiBase={apiBase}
+            />
+          </main>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/profile/profile-form.tsx
+++ b/src/screendrafts.ui/src/app/profile/profile-form.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useState } from "react";
+import { GetUserResponse } from "@/lib/dto";
+import AvatarUpload from "./avatar-upload";
+
+type Tab = 'personal' | 'password' | 'social' | 'avatar';
+
+interface ProfileFormProps {
+  profile: GetUserResponse | null;
+  accessToken: string | undefined;
+  apiBase: string;
+}
+
+const INPUT = "border border-sd-ink/20 bg-sd-paper px-3 py-2 text-sd-ink font-sans text-sm focus:outline-none focus:ring-2 focus:ring-sd-blue rounded w-full";
+const LABEL = "block text-[11px] font-mono tracking-widest text-sd-ink/60 uppercase mb-1";
+const BTN_PRIMARY = "bg-sd-red text-white font-oswald tracking-wide uppercase px-4 py-2 hover:bg-sd-red/90 disabled:opacity-50 transition-colors";
+
+type Status = { type: 'success' | 'error'; message: string } | null;
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className={LABEL}>{label}</label>
+      {children}
+    </div>
+  );
+}
+
+function Feedback({ status }: { status: Status }) {
+  if (!status) return null;
+  return (
+    <p className={`text-[13px] ${status.type === 'success' ? 'text-green-700' : 'text-sd-red'}`}>
+      {status.message}
+    </p>
+  );
+}
+
+function PersonalTab({ profile, accessToken, apiBase }: ProfileFormProps) {
+  const [firstName, setFirstName] = useState(profile?.firstName ?? '');
+  const [lastName, setLastName] = useState(profile?.lastName ?? '');
+  const [status, setStatus] = useState<Status>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    setStatus(null);
+    try {
+      const res = await fetch(`${apiBase}/users/profile`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({ firstName, lastName }),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      setStatus({ type: 'success', message: 'Profile updated.' });
+    } catch {
+      setStatus({ type: 'error', message: 'Failed to save. Please try again.' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <Field label="First Name">
+        <input className={INPUT} value={firstName} onChange={e => setFirstName(e.target.value)} />
+      </Field>
+      <Field label="Last Name">
+        <input className={INPUT} value={lastName} onChange={e => setLastName(e.target.value)} />
+      </Field>
+      <div className="pt-1 flex items-center gap-4">
+        <button className={BTN_PRIMARY} onClick={handleSave} disabled={saving}>
+          {saving ? 'SAVING…' : 'SAVE CHANGES'}
+        </button>
+        <Feedback status={status} />
+      </div>
+    </div>
+  );
+}
+
+function PasswordTab({ accessToken, apiBase }: { accessToken: string | undefined; apiBase: string }) {
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [status, setStatus] = useState<Status>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    if (next !== confirm) {
+      setStatus({ type: 'error', message: 'New passwords do not match.' });
+      return;
+    }
+    if (next.length < 8) {
+      setStatus({ type: 'error', message: 'New password must be at least 8 characters.' });
+      return;
+    }
+    setSaving(true);
+    setStatus(null);
+    try {
+      const res = await fetch(`${apiBase}/users/profile/password`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({ currentPassword: current, newPassword: next, confirmNewPassword: confirm }),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      setStatus({ type: 'success', message: 'Password changed.' });
+      setCurrent(''); setNext(''); setConfirm('');
+    } catch {
+      setStatus({ type: 'error', message: 'Failed to change password. Check your current password and try again.' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <Field label="Current Password">
+        <input type="password" className={INPUT} value={current} onChange={e => setCurrent(e.target.value)} autoComplete="current-password" />
+      </Field>
+      <Field label="New Password">
+        <input type="password" className={INPUT} value={next} onChange={e => setNext(e.target.value)} autoComplete="new-password" />
+      </Field>
+      <Field label="Confirm New Password">
+        <input type="password" className={INPUT} value={confirm} onChange={e => setConfirm(e.target.value)} autoComplete="new-password" />
+      </Field>
+      <div className="pt-1 flex items-center gap-4">
+        <button className={BTN_PRIMARY} onClick={handleSave} disabled={saving}>
+          {saving ? 'SAVING…' : 'CHANGE PASSWORD'}
+        </button>
+        <Feedback status={status} />
+      </div>
+    </div>
+  );
+}
+
+function SocialTab({ profile, accessToken, apiBase }: ProfileFormProps) {
+  const [twitter, setTwitter] = useState(profile?.twitterHandle ?? '');
+  const [instagram, setInstagram] = useState(profile?.instagramHandle ?? '');
+  const [letterboxd, setLetterboxd] = useState(profile?.letterboxdHandle ?? '');
+  const [bluesky, setBluesky] = useState(profile?.blueskyHandle ?? '');
+  const [status, setStatus] = useState<Status>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    setStatus(null);
+    try {
+      const res = await fetch(`${apiBase}/users/profile/social`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({ twitter, instagram, letterboxd, bluesky }),
+      });
+      if (!res.ok) throw new Error(`${res.status}`);
+      setStatus({ type: 'success', message: 'Social profiles updated.' });
+    } catch {
+      setStatus({ type: 'error', message: 'Failed to save. Please try again.' });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <Field label="Twitter / X (without @)">
+        <input className={INPUT} value={twitter} onChange={e => setTwitter(e.target.value)} placeholder="yourhandle" />
+      </Field>
+      <Field label="Instagram">
+        <input className={INPUT} value={instagram} onChange={e => setInstagram(e.target.value)} placeholder="yourhandle" />
+      </Field>
+      <Field label="Letterboxd">
+        <input className={INPUT} value={letterboxd} onChange={e => setLetterboxd(e.target.value)} placeholder="yourusername" />
+      </Field>
+      <Field label="Bluesky">
+        <input className={INPUT} value={bluesky} onChange={e => setBluesky(e.target.value)} placeholder="yourhandle" />
+      </Field>
+      <div className="pt-1 flex items-center gap-4">
+        <button className={BTN_PRIMARY} onClick={handleSave} disabled={saving}>
+          {saving ? 'SAVING…' : 'SAVE SOCIAL PROFILES'}
+        </button>
+        <Feedback status={status} />
+      </div>
+    </div>
+  );
+}
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'personal', label: 'Personal Info' },
+  { id: 'password', label: 'Password' },
+  { id: 'social', label: 'Social Profiles' },
+  { id: 'avatar', label: 'Avatar' },
+];
+
+export default function ProfileForm({ profile, accessToken, apiBase }: ProfileFormProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('personal');
+
+  return (
+    <div className="bg-white border border-sd-ink/10">
+      {/* Tab bar */}
+      <div className="flex border-b border-sd-ink/10">
+        {TABS.map(({ id, label }) => (
+          <button
+            key={id}
+            onClick={() => setActiveTab(id)}
+            className={`px-5 py-3.5 font-oswald text-[13px] tracking-wide uppercase transition-colors border-b-2 -mb-px ${
+              activeTab === id
+                ? 'border-sd-red text-sd-ink font-semibold'
+                : 'border-transparent text-sd-ink/40 hover:text-sd-ink'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="p-7 border-b border-sd-ink/10 min-h-[320px]">
+        {activeTab === 'personal' && (
+          <PersonalTab profile={profile} accessToken={accessToken} apiBase={apiBase} />
+        )}
+        {activeTab === 'password' && (
+          <PasswordTab accessToken={accessToken} apiBase={apiBase} />
+        )}
+        {activeTab === 'social' && (
+          <SocialTab profile={profile} accessToken={accessToken} apiBase={apiBase} />
+        )}
+        {activeTab === 'avatar' && (
+          <AvatarUpload
+            currentAvatarUrl={profile?.profilePicturePath}
+            displayName={[profile?.firstName, profile?.lastName].filter(Boolean).join(' ') || profile?.email || 'User'}
+            accessToken={accessToken}
+            apiBase={apiBase}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/services/admin/fetch-admin.ts
+++ b/src/screendrafts.ui/src/services/admin/fetch-admin.ts
@@ -1,0 +1,82 @@
+import { auth } from "@/auth";
+import { env } from "@/lib/env";
+
+const apiBase = env.apiUrl;
+
+// Local types — will move to dto.ts after NSwag regeneration when backend adds these endpoints.
+export interface AdminUserItem {
+  publicId: string;
+  displayName: string;
+  email: string;
+  roles: string[];
+}
+
+export interface AdminRoleItem {
+  name: string;
+  description?: string;
+}
+
+async function authHeaders(): Promise<HeadersInit> {
+  const session = await auth();
+  if (session?.accessToken) {
+    return { Authorization: `Bearer ${session.accessToken}` };
+  }
+  return {};
+}
+
+export async function fetchAdminUsers(search?: string): Promise<AdminUserItem[]> {
+  try {
+    const url = new URL(`${apiBase}/admin/users`);
+    if (search) url.searchParams.set("search", search);
+    const response = await fetch(url.toString(), {
+      headers: await authHeaders(),
+      next: { revalidate: 0 },
+    });
+    if (!response.ok) {
+      console.error(`[fetchAdminUsers] ${response.status}`);
+      return [];
+    }
+    return response.json() as Promise<AdminUserItem[]>;
+  } catch (err) {
+    console.error("[fetchAdminUsers] error:", err);
+    return [];
+  }
+}
+
+export async function fetchAdminRoles(): Promise<AdminRoleItem[]> {
+  try {
+    const response = await fetch(`${apiBase}/admin/roles`, {
+      headers: await authHeaders(),
+      next: { revalidate: 0 },
+    });
+    if (!response.ok) {
+      console.error(`[fetchAdminRoles] ${response.status}`);
+      return [];
+    }
+    return response.json() as Promise<AdminRoleItem[]>;
+  } catch (err) {
+    console.error("[fetchAdminRoles] error:", err);
+    return [];
+  }
+}
+
+export async function fetchRolePermissions(roleName: string): Promise<string[]> {
+  try {
+    const response = await fetch(
+      `${apiBase}/admin/roles/${encodeURIComponent(roleName)}/permissions`,
+      {
+        headers: await authHeaders(),
+        next: { revalidate: 0 },
+      }
+    );
+    if (!response.ok) {
+      console.error(`[fetchRolePermissions] ${response.status}`);
+      return [];
+    }
+    const data = await response.json() as { permissions?: string[] };
+    return data.permissions ?? [];
+  } catch (err) {
+    console.error("[fetchRolePermissions] error:", err);
+    return [];
+  }
+}

--- a/src/screendrafts.ui/src/services/profile/fetch-profile.ts
+++ b/src/screendrafts.ui/src/services/profile/fetch-profile.ts
@@ -1,0 +1,30 @@
+import { auth } from "@/auth";
+import { env } from "@/lib/env";
+import { GetUserResponse } from "@/lib/dto";
+
+const apiBase = env.apiUrl;
+
+async function authHeaders(): Promise<HeadersInit> {
+  const session = await auth();
+  if (session?.accessToken) {
+    return { Authorization: `Bearer ${session.accessToken}` };
+  }
+  return {};
+}
+
+export async function fetchProfile(): Promise<GetUserResponse | null> {
+  try {
+    const response = await fetch(`${apiBase}/users/profile`, {
+      headers: await authHeaders(),
+      next: { revalidate: 0 },
+    });
+    if (!response.ok) {
+      console.error(`[fetchProfile] ${response.status} ${response.statusText}`);
+      return null;
+    }
+    return response.json() as Promise<GetUserResponse>;
+  } catch (err) {
+    console.error("[fetchProfile] error:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- **`/profile`** — Authenticated user profile page with a two-column layout (avatar sidebar + tabbed form). Tabs cover Personal Info (name), Password change, Social Profiles (Twitter/X, Instagram, Letterboxd, Bluesky), and Avatar upload. Redirects to sign-in if no session.
- **`/admin`** — Administration dashboard guarded by `session.roles.includes('admin')`, redirecting to `/` for unauthorised visitors. Cards for User Management (search + role pills + slide-over), Password Reset (user search → trigger Keycloak reset email), and a collapsible Roles & Permissions reference accordion.

## New files

| Path | Purpose |
|---|---|
| `src/services/profile/fetch-profile.ts` | `fetchProfile()` — authenticated `GET /users/profile` |
| `src/services/admin/fetch-admin.ts` | `fetchAdminUsers()`, `fetchAdminRoles()`, `fetchRolePermissions()` with local types pending NSwag regen |
| `src/app/profile/page.tsx` | Server component — auth redirect + initial data fetch |
| `src/app/profile/profile-form.tsx` | Client component — four-tab form with inline feedback |
| `src/app/profile/avatar-upload.tsx` | Client component — 2 MB guard, multipart upload, initials fallback |
| `src/app/admin/page.tsx` | Server component — role guard, parallel data fetch, card grid |
| `src/app/admin/user-table.tsx` | Client component — debounced search, role badges, opens slide-over |
| `src/app/admin/manage-roles-panel.tsx` | Client component — fixed slide-over, optimistic role add/remove with revert |
| `src/app/admin/password-reset-card.tsx` | Client component — search-select-confirm flow, `POST …/password-reset` |
| `src/app/admin/roles-accordion.tsx` | Client component — lazy-load permissions on expand |

## Design decisions / known gaps

- **Auth token to client**: `accessToken` is passed from the server component as a prop (no `SessionProvider` yet in `providers.tsx`). Avoids modifying the providers for now.
- **`dto.ts` shape mismatch**: `GetUserResponse` uses flat `twitterHandle` / `instagramHandle` / `letterboxdHandle` / `blueskyHandle` fields (no nested `social` object). The social tab maps to these directly. `PUT /users/profile` body type in dto.ts is the generic `Request` — using the correct `{ firstName, lastName }` shape per spec since the generated client is stale here.
- **Missing backend endpoints**: `GET /admin/users`, `GET /admin/roles` (list), `GET /admin/roles/{role}/permissions`, `PUT /users/profile/password`, `PUT /users/profile/social`, and `POST /users/profile/avatar` are not yet in `dto.ts`. Local types (`AdminUserItem`, `AdminRoleItem`) are defined in `fetch-admin.ts` and can be promoted after NSwag regeneration.
- **Type check**: Zero errors in new files. Pre-existing parse errors in the auto-generated `dto.ts` are unchanged.

## Test plan

- [ ] Visit `/profile` without a session → redirected to sign-in
- [ ] Signed in: sidebar shows avatar/initials, name, email, social handles
- [ ] Personal Info tab: update name → inline "Profile updated." success
- [ ] Password tab: mismatched confirm → client-side error; successful change → success message
- [ ] Social tab: save handles → success; verify fields pre-populated on reload
- [ ] Avatar tab: upload >2 MB file → "File must be under 2MB." client guard; valid file → avatar updates
- [ ] Visit `/admin` without `admin` role → redirected to `/`
- [ ] Admin: search users → table filters; open Manage Roles → add/remove with optimistic UI
- [ ] Admin: password reset → search, select, confirm, send → "Reset email sent" message
- [ ] Admin: Roles accordion → expand row lazy-loads permissions as `font-mono` chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)