### PR TITLE
feat: Add Draft Management admin feature (skeleton)

### DIFF
--- a/src/screendrafts.ui/src/app/admin/drafts/[draftId]/edit/page.tsx
+++ b/src/screendrafts.ui/src/app/admin/drafts/[draftId]/edit/page.tsx
@@ -1,0 +1,62 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import SiteHeader from "@/components/layout/header/site-header";
+import SiteFooter from "@/components/layout/footer/site-footer";
+import { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Edit Draft" };
+export const dynamic = "force-dynamic";
+
+const ADMIN_ROLES = ["Administrator", "SuperAdministrator"];
+
+// TODO: implement full draft edit page
+export default async function EditDraftPage({
+  params,
+}: {
+  params: Promise<{ draftId: string }>;
+}) {
+  const session = await auth();
+  const isAdmin = session?.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false;
+  if (!isAdmin) redirect("/");
+
+  const { draftId } = await params;
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/admin" />
+
+      <div className="px-6 md:px-10 py-10 max-w-[900px] mx-auto">
+        <p className="font-mono text-[11px] tracking-widest text-sd-ink/50 mb-6">
+          <Link href="/admin" className="hover:text-sd-ink/70">ADMIN</Link>
+          {" / "}
+          <Link href="/admin/drafts" className="hover:text-sd-ink/70">DRAFTS</Link>
+          {" / EDIT"}
+        </p>
+
+        <h1 className="font-oswald font-bold text-[48px] leading-none text-sd-ink mb-6">
+          EDIT DRAFT
+        </h1>
+
+        <div className="bg-white border border-sd-ink/10 p-8">
+          <p className="font-mono text-sm text-sd-ink/60 mb-4">
+            Draft ID: <span className="text-sd-ink">{draftId}</span>
+          </p>
+          <p className="text-sd-ink/50 text-sm">
+            Edit functionality coming soon.
+          </p>
+          <div className="mt-6">
+            <Link
+              href="/admin/drafts"
+              className="border border-sd-ink/20 text-sd-ink font-sans text-sm px-4 py-2 hover:bg-sd-ink/5 transition-colors rounded"
+            >
+              ← Back to Drafts
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/drafts/new/create-draft-form.tsx
+++ b/src/screendrafts.ui/src/app/admin/drafts/new/create-draft-form.tsx
@@ -1,0 +1,610 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  AdminSeriesOption,
+  AdminHostOption,
+  AdminDrafterOption,
+  createDraft,
+  createDraftPart,
+  addHostToDraftPart,
+  addParticipantToDraftPart,
+  setDraftCategories,
+  setDraftCampaign,
+} from "@/services/admin/fetch-admin-drafts";
+import { CampaignResponse, CategoryResponse, SmartEnumResponse } from "@/lib/dto";
+
+const LABEL = "block text-[11px] font-mono tracking-widest text-sd-ink/60 uppercase mb-1";
+const INPUT =
+  "border border-sd-ink/20 bg-sd-paper px-3 py-2 text-sd-ink font-sans text-sm focus:outline-none focus:ring-2 focus:ring-sd-blue rounded w-full";
+const SELECT =
+  "border border-sd-ink/20 bg-sd-paper px-3 py-2 text-sd-ink font-sans text-sm focus:outline-none focus:ring-2 focus:ring-sd-blue rounded w-full";
+const BTN_PRIMARY =
+  "bg-sd-red text-white font-oswald font-medium tracking-wide uppercase px-5 py-2.5 hover:bg-sd-red/90 disabled:opacity-50 transition-colors";
+const BTN_SECONDARY =
+  "border border-sd-ink/20 text-sd-ink font-sans text-sm px-4 py-2 hover:bg-sd-ink/5 disabled:opacity-50 transition-colors rounded";
+const SECTION_HEADING =
+  "font-oswald font-bold text-[18px] tracking-wide uppercase text-sd-ink mb-4 pb-2 border-b border-sd-ink/10";
+
+// Max positions per draft type name (locked = user cannot change)
+function getMaxPositionsConfig(draftTypeName: string): { max: number; locked: boolean } {
+  switch (draftTypeName) {
+    case "Standard":
+      return { max: 7, locked: true };
+    case "SpeedDraft":
+      return { max: 7, locked: true };
+    default:
+      return { max: 5, locked: false };
+  }
+}
+
+interface PartConfig {
+  partIndex: number;
+  minPositions: number;
+  maxPositions: number;
+  maxLocked: boolean;
+  collapsed: boolean;
+}
+
+interface SelectedHost {
+  publicId: string;
+  displayName: string;
+  role: "Primary" | "CoHost";
+}
+
+interface Props {
+  seriesList: AdminSeriesOption[];
+  hostList: AdminHostOption[];
+  drafterList: AdminDrafterOption[];
+  categoryList: CategoryResponse[];
+  campaignList: CampaignResponse[];
+  accessToken: string;
+}
+
+export default function CreateDraftForm({
+  seriesList,
+  hostList,
+  drafterList,
+  categoryList,
+  campaignList,
+  accessToken,
+}: Props) {
+  const router = useRouter();
+
+  // Section 1 — Core metadata
+  const [title, setTitle] = useState("");
+  const [selectedSeriesId, setSelectedSeriesId] = useState("");
+  const [selectedDraftType, setSelectedDraftType] = useState<SmartEnumResponse | null>(null);
+
+  // Section 2 — Parts
+  const [numParts, setNumParts] = useState(1);
+  const [parts, setParts] = useState<PartConfig[]>([
+    { partIndex: 1, minPositions: 1, maxPositions: 7, maxLocked: true, collapsed: false },
+  ]);
+
+  // Section 3 — Hosts
+  const [hosts, setHosts] = useState<SelectedHost[]>([]);
+  const [hostSearch, setHostSearch] = useState("");
+
+  // Section 4 — Drafters
+  const [selectedDrafterIds, setSelectedDrafterIds] = useState<Set<string>>(new Set());
+  const [drafterSearch, setDrafterSearch] = useState("");
+
+  // Section 5 — Categories
+  const [selectedCategoryIds, setSelectedCategoryIds] = useState<Set<string>>(new Set());
+
+  // Section 6 — Campaign
+  const [campaignId, setCampaignId] = useState("");
+
+  // Submit state
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Derived: available draft types for selected series
+  const selectedSeries = seriesList.find((s) => s.publicId === selectedSeriesId);
+  const availableDraftTypes = selectedSeries?.allowedDraftTypes ?? [];
+
+  // When series changes, reset draft type
+  function handleSeriesChange(seriesId: string) {
+    setSelectedSeriesId(seriesId);
+    const series = seriesList.find((s) => s.publicId === seriesId);
+    const defaultType = series?.defaultDraftType ?? series?.allowedDraftTypes?.[0] ?? null;
+    setSelectedDraftType(defaultType ?? null);
+    if (defaultType?.name) {
+      syncPartsToType(defaultType.name, numParts);
+    }
+  }
+
+  function handleDraftTypeChange(typeName: string) {
+    const typeObj = availableDraftTypes.find((t) => t.name === typeName) ?? null;
+    setSelectedDraftType(typeObj);
+    syncPartsToType(typeName, numParts);
+  }
+
+  function syncPartsToType(typeName: string, count: number) {
+    const { max, locked } = getMaxPositionsConfig(typeName);
+    setParts(
+      Array.from({ length: count }, (_, i) => ({
+        partIndex: i + 1,
+        minPositions: 1,
+        maxPositions: max,
+        maxLocked: locked,
+        collapsed: i > 0,
+      }))
+    );
+  }
+
+  function handleNumPartsChange(n: number) {
+    const count = Math.max(1, n);
+    setNumParts(count);
+    const typeName = selectedDraftType?.name ?? "";
+    const { max, locked } = getMaxPositionsConfig(typeName);
+    setParts(
+      Array.from({ length: count }, (_, i) => ({
+        partIndex: i + 1,
+        minPositions: 1,
+        maxPositions: parts[i]?.maxPositions ?? max,
+        maxLocked: locked,
+        collapsed: i > 0,
+      }))
+    );
+  }
+
+  function updatePartMax(idx: number, value: number) {
+    setParts((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, maxPositions: Math.max(1, value) } : p))
+    );
+  }
+
+  function togglePartCollapsed(idx: number) {
+    setParts((prev) =>
+      prev.map((p, i) => (i === idx ? { ...p, collapsed: !p.collapsed } : p))
+    );
+  }
+
+  // Hosts
+  function addHost(host: AdminHostOption) {
+    if (hosts.some((h) => h.publicId === host.publicId)) return;
+    setHosts((prev) => [
+      ...prev,
+      { publicId: host.publicId, displayName: host.displayName, role: "CoHost" },
+    ]);
+  }
+
+  function removeHost(publicId: string) {
+    setHosts((prev) => prev.filter((h) => h.publicId !== publicId));
+  }
+
+  function setHostRole(publicId: string, role: "Primary" | "CoHost") {
+    setHosts((prev) =>
+      prev.map((h) => (h.publicId === publicId ? { ...h, role } : h))
+    );
+  }
+
+  // Drafters
+  function toggleDrafter(id: string) {
+    setSelectedDrafterIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  // Categories
+  function toggleCategory(id: string) {
+    setSelectedCategoryIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  const filteredHosts = hostList.filter(
+    (h) =>
+      !hosts.some((sel) => sel.publicId === h.publicId) &&
+      h.displayName.toLowerCase().includes(hostSearch.toLowerCase())
+  );
+
+  const filteredDrafters = drafterList.filter((d) =>
+    d.displayName.toLowerCase().includes(drafterSearch.toLowerCase())
+  );
+
+  const canSubmit = title.trim() !== "" && selectedSeriesId !== "" && selectedDraftType !== null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || submitting) return;
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      // Step 1: Create draft
+      const { publicId: draftPublicId } = await createDraft(accessToken, {
+        title: title.trim(),
+        draftType: selectedDraftType!.value ?? 0,
+        seriesId: selectedSeriesId,
+      });
+
+      // Step 2: Create parts
+      const partPublicIds: string[] = [];
+      for (const part of parts) {
+        const partId = await createDraftPart(accessToken, draftPublicId, {
+          publicId: draftPublicId,
+          partIndex: parts.length === 1 ? 1 : part.partIndex,
+          minimumPosition: part.minPositions,
+          maximumPosition: part.maxPositions,
+        });
+        partPublicIds.push(partId);
+      }
+
+      // Step 3: Add hosts to each part
+      if (hosts.length > 0) {
+        for (const partId of partPublicIds) {
+          for (const host of hosts) {
+            await addHostToDraftPart(accessToken, partId, {
+              draftPartId: partId,
+              hostPublicId: host.publicId,
+              hostRole: host.role === "Primary" ? 0 : 1,
+            });
+          }
+        }
+      }
+
+      // Step 4: Add drafters to each part
+      if (selectedDrafterIds.size > 0) {
+        for (const partId of partPublicIds) {
+          for (const drafterId of selectedDrafterIds) {
+            await addParticipantToDraftPart(accessToken, partId, {
+              draftPartId: partId,
+              participantPublicId: drafterId,
+              participantKind: 0, // Drafter
+            });
+          }
+        }
+      }
+
+      // Step 5: Set categories
+      if (selectedCategoryIds.size > 0) {
+        await setDraftCategories(accessToken, draftPublicId, [...selectedCategoryIds]);
+      }
+
+      // Step 6: Set campaign
+      if (campaignId) {
+        await setDraftCampaign(accessToken, draftPublicId, campaignId);
+      }
+
+      // TODO: redirect to /admin/drafts/{draftPublicId}/edit once edit page exists
+      router.push(`/admin/drafts`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An unexpected error occurred.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-10">
+      {/* ── Section 1: Core metadata ── */}
+      <section>
+        <h2 className={SECTION_HEADING}>Core Details</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="md:col-span-2">
+            <label className={LABEL}>
+              Title <span className="text-sd-red">*</span>
+            </label>
+            <input
+              type="text"
+              className={INPUT}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Draft title"
+              required
+            />
+          </div>
+
+          <div>
+            <label className={LABEL}>
+              Series <span className="text-sd-red">*</span>
+            </label>
+            <select
+              className={SELECT}
+              value={selectedSeriesId}
+              onChange={(e) => handleSeriesChange(e.target.value)}
+              required
+            >
+              <option value="">— Select series —</option>
+              {seriesList.map((s) => (
+                <option key={s.publicId} value={s.publicId}>
+                  {s.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className={LABEL}>
+              Draft Type <span className="text-sd-red">*</span>
+            </label>
+            <select
+              className={SELECT}
+              value={selectedDraftType?.name ?? ""}
+              onChange={(e) => handleDraftTypeChange(e.target.value)}
+              disabled={availableDraftTypes.length === 0}
+              required
+            >
+              <option value="">— Select draft type —</option>
+              {availableDraftTypes.map((t) => (
+                <option key={t.name} value={t.name ?? ""}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+            {selectedSeriesId && availableDraftTypes.length === 0 && (
+              <p className="text-[11px] text-sd-ink/50 mt-1 font-mono">
+                No draft types available for this series.
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Section 2: Parts configuration ── */}
+      <section>
+        <h2 className={SECTION_HEADING}>Parts Configuration</h2>
+        <div className="mb-6 max-w-[160px]">
+          <label className={LABEL}>Number of Parts</label>
+          <input
+            type="number"
+            min={1}
+            max={10}
+            className={INPUT}
+            value={numParts}
+            onChange={(e) => handleNumPartsChange(parseInt(e.target.value, 10) || 1)}
+          />
+        </div>
+
+        <div className="space-y-3">
+          {parts.map((part, idx) => (
+            <div key={idx} className="border border-sd-ink/10 rounded">
+              <button
+                type="button"
+                className="w-full flex items-center justify-between px-4 py-3 text-left bg-sd-ink/5 hover:bg-sd-ink/10 transition-colors"
+                onClick={() => togglePartCollapsed(idx)}
+              >
+                <span className="font-oswald font-medium text-sd-ink tracking-wide">
+                  {numParts > 1 ? `Part ${part.partIndex}` : "Part Configuration"}
+                </span>
+                <span className="text-sd-ink/50 text-sm">{part.collapsed ? "▶" : "▼"}</span>
+              </button>
+
+              {!part.collapsed && (
+                <div className="px-4 py-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  {numParts > 1 && (
+                    <div>
+                      <label className={LABEL}>Part Index</label>
+                      <div className="px-3 py-2 bg-sd-ink/5 rounded text-sd-ink text-sm font-mono">
+                        {part.partIndex}
+                      </div>
+                    </div>
+                  )}
+                  <div>
+                    <label className={LABEL}>Min Positions</label>
+                    <div className="px-3 py-2 bg-sd-ink/5 rounded text-sd-ink text-sm font-mono">
+                      {part.minPositions}
+                    </div>
+                  </div>
+                  <div>
+                    <label className={LABEL}>Max Positions</label>
+                    {part.maxLocked ? (
+                      <div className="px-3 py-2 bg-sd-ink/5 rounded text-sd-ink text-sm font-mono flex items-center gap-2">
+                        {part.maxPositions}
+                        <span className="text-[10px] text-sd-ink/40 font-mono uppercase tracking-wide">
+                          locked
+                        </span>
+                      </div>
+                    ) : (
+                      <input
+                        type="number"
+                        min={1}
+                        className={INPUT}
+                        value={part.maxPositions}
+                        onChange={(e) =>
+                          updatePartMax(idx, parseInt(e.target.value, 10) || 1)
+                        }
+                      />
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Section 3: Hosts ── */}
+      <section>
+        <h2 className={SECTION_HEADING}>Hosts (Optional)</h2>
+
+        {hosts.length > 0 && (
+          <div className="mb-4 space-y-2">
+            {hosts.map((h) => (
+              <div
+                key={h.publicId}
+                className="flex items-center justify-between gap-3 px-3 py-2 bg-white border border-sd-ink/10 rounded"
+              >
+                <span className="text-sm text-sd-ink font-medium">{h.displayName}</span>
+                <div className="flex items-center gap-3">
+                  <label className="flex items-center gap-1.5 text-sm text-sd-ink/70 cursor-pointer">
+                    <input
+                      type="radio"
+                      name={`host-role-${h.publicId}`}
+                      checked={h.role === "Primary"}
+                      onChange={() => setHostRole(h.publicId, "Primary")}
+                      className="accent-sd-red"
+                    />
+                    Primary
+                  </label>
+                  <label className="flex items-center gap-1.5 text-sm text-sd-ink/70 cursor-pointer">
+                    <input
+                      type="radio"
+                      name={`host-role-${h.publicId}`}
+                      checked={h.role === "CoHost"}
+                      onChange={() => setHostRole(h.publicId, "CoHost")}
+                      className="accent-sd-red"
+                    />
+                    Co-Host
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => removeHost(h.publicId)}
+                    className="text-sd-ink/40 hover:text-sd-red text-lg leading-none"
+                    aria-label={`Remove ${h.displayName}`}
+                  >
+                    ×
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="border border-sd-ink/10 rounded p-4 bg-white">
+          <input
+            type="text"
+            placeholder="Search hosts…"
+            className={`${INPUT} mb-3`}
+            value={hostSearch}
+            onChange={(e) => setHostSearch(e.target.value)}
+          />
+          <div className="max-h-40 overflow-y-auto space-y-1">
+            {filteredHosts.length === 0 ? (
+              <p className="text-sm text-sd-ink/40 font-mono">No hosts found.</p>
+            ) : (
+              filteredHosts.map((h) => (
+                <button
+                  key={h.publicId}
+                  type="button"
+                  onClick={() => addHost(h)}
+                  className="w-full text-left px-3 py-1.5 text-sm text-sd-ink hover:bg-sd-ink/5 rounded transition-colors"
+                >
+                  {h.displayName}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Section 4: Participants (Drafters) ── */}
+      <section>
+        <h2 className={SECTION_HEADING}>Participants (Optional)</h2>
+        <div className="border border-sd-ink/10 rounded p-4 bg-white">
+          <input
+            type="text"
+            placeholder="Search drafters…"
+            className={`${INPUT} mb-3`}
+            value={drafterSearch}
+            onChange={(e) => setDrafterSearch(e.target.value)}
+          />
+          <div className="max-h-48 overflow-y-auto space-y-1">
+            {filteredDrafters.map((d) => {
+              const checked = selectedDrafterIds.has(d.publicId);
+              return (
+                <label
+                  key={d.publicId}
+                  className="flex items-center gap-2 px-3 py-1.5 text-sm text-sd-ink hover:bg-sd-ink/5 rounded cursor-pointer"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleDrafter(d.publicId)}
+                    className="accent-sd-red"
+                  />
+                  {d.displayName}
+                </label>
+              );
+            })}
+          </div>
+          {selectedDrafterIds.size > 0 && (
+            <p className="mt-2 text-[11px] font-mono text-sd-ink/50">
+              {selectedDrafterIds.size} drafter{selectedDrafterIds.size !== 1 ? "s" : ""} selected
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* ── Section 5: Category ── */}
+      <section>
+        <h2 className={SECTION_HEADING}>Category (Optional)</h2>
+        <div className="border border-sd-ink/10 rounded p-4 bg-white">
+          <div className="max-h-40 overflow-y-auto columns-2 gap-4">
+            {categoryList.map((c) => {
+              const checked = selectedCategoryIds.has(c.publicId);
+              return (
+                <label
+                  key={c.publicId}
+                  className="flex items-center gap-2 mb-1 text-sm text-sd-ink hover:bg-sd-ink/5 rounded px-2 py-1 cursor-pointer break-inside-avoid"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleCategory(c.publicId)}
+                    className="accent-sd-red"
+                  />
+                  {c.name}
+                </label>
+              );
+            })}
+          </div>
+          {selectedCategoryIds.size > 0 && (
+            <p className="mt-2 text-[11px] font-mono text-sd-ink/50">
+              {selectedCategoryIds.size} categor{selectedCategoryIds.size !== 1 ? "ies" : "y"} selected
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* ── Section 6: Campaign ── */}
+      <section>
+        <h2 className={SECTION_HEADING}>Campaign (Optional)</h2>
+        <div className="max-w-sm">
+          <select
+            className={SELECT}
+            value={campaignId}
+            onChange={(e) => setCampaignId(e.target.value)}
+          >
+            <option value="">— No campaign —</option>
+            {campaignList.map((c) => (
+              <option key={c.publicId} value={c.publicId}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      {/* ── Error + Submit ── */}
+      {error && (
+        <div className="border border-red-300 bg-red-50 text-red-800 text-sm px-4 py-3 rounded">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-4 pt-2">
+        <button
+          type="submit"
+          disabled={!canSubmit || submitting}
+          className={BTN_PRIMARY}
+        >
+          {submitting ? "Creating…" : "Create Draft"}
+        </button>
+        <a href="/admin/drafts" className={BTN_SECONDARY}>
+          Cancel
+        </a>
+      </div>
+    </form>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/drafts/new/page.tsx
+++ b/src/screendrafts.ui/src/app/admin/drafts/new/page.tsx
@@ -1,0 +1,67 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import SiteHeader from "@/components/layout/header/site-header";
+import SiteFooter from "@/components/layout/footer/site-footer";
+import CreateDraftForm from "./create-draft-form";
+import {
+  listAllSeries,
+  searchAllHosts,
+  listAllDrafters,
+  listAllCategories,
+  listAllCampaigns,
+} from "@/services/admin/fetch-admin-drafts";
+import { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Create Draft" };
+export const dynamic = "force-dynamic";
+
+const ADMIN_ROLES = ["Administrator", "SuperAdministrator"];
+
+export default async function CreateDraftPage() {
+  const session = await auth();
+  const isAdmin = session?.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false;
+  if (!isAdmin) redirect("/");
+
+  if (!session?.accessToken) redirect("/");
+
+  const [seriesList, hostList, drafterList, categoryList, campaignList] = await Promise.all([
+    listAllSeries(session.accessToken),
+    searchAllHosts(session.accessToken),
+    listAllDrafters(session.accessToken),
+    listAllCategories(session.accessToken),
+    listAllCampaigns(session.accessToken),
+  ]);
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/admin" />
+
+      <div className="px-6 md:px-10 py-10 max-w-[900px] mx-auto">
+        <p className="font-mono text-[11px] tracking-widest text-sd-ink/50 mb-6">
+          <Link href="/admin" className="hover:text-sd-ink/70">ADMIN</Link>
+          {" / "}
+          <Link href="/admin/drafts" className="hover:text-sd-ink/70">DRAFTS</Link>
+          {" / NEW"}
+        </p>
+
+        <h1 className="font-oswald font-bold text-[48px] leading-none text-sd-ink mb-10">
+          CREATE DRAFT
+        </h1>
+
+        <div className="bg-white border border-sd-ink/10 p-8">
+          <CreateDraftForm
+            seriesList={seriesList}
+            hostList={hostList}
+            drafterList={drafterList}
+            categoryList={categoryList}
+            campaignList={campaignList}
+            accessToken={session.accessToken}
+          />
+        </div>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/app/admin/drafts/page.tsx
+++ b/src/screendrafts.ui/src/app/admin/drafts/page.tsx
@@ -1,0 +1,133 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import SiteHeader from "@/components/layout/header/site-header";
+import SiteFooter from "@/components/layout/footer/site-footer";
+import { listAdminDrafts } from "@/services/admin/fetch-admin-drafts";
+import { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Draft Management" };
+export const dynamic = "force-dynamic";
+
+const ADMIN_ROLES = ["Administrator", "SuperAdministrator"];
+
+// Draft status numeric values from backend SmartEnum
+const STATUS_LABELS: Record<number, string> = {
+  0: "Draft",
+  1: "Scheduled",
+  2: "Active",
+  3: "Paused",
+  4: "Completed",
+};
+
+function AdminCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white border border-sd-ink/10">
+      <div className="flex items-center gap-3 px-6 py-4 border-b border-sd-ink/10 bg-sd-ink">
+        <div className="w-1 h-5 bg-sd-red shrink-0" />
+        <h2 className="font-oswald font-bold text-[16px] tracking-wide uppercase text-white">
+          {title}
+        </h2>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  );
+}
+
+export default async function AdminDraftsPage() {
+  const session = await auth();
+  const isAdmin = session?.roles?.some((r) => ADMIN_ROLES.includes(r)) ?? false;
+  if (!isAdmin) redirect("/");
+
+  const drafts = await listAdminDrafts(session?.accessToken);
+
+  // Show Active (2) and Paused (3) first; fall back to all if none match
+  const activePaused = drafts.filter(
+    (d) => d.draftStatus === 2 || d.draftStatus === 3
+  );
+  const displayDrafts = activePaused.length > 0 ? activePaused : drafts;
+
+  return (
+    <div className="min-h-screen bg-light-blue">
+      <SiteHeader activePath="/admin" />
+
+      <div className="px-6 md:px-10 py-10 max-w-[1200px] mx-auto">
+        <p className="font-mono text-[11px] tracking-widest text-sd-ink/50 mb-6">
+          / ADMIN / DRAFTS
+        </p>
+
+        <div className="flex items-end justify-between mb-10">
+          <h1 className="font-oswald font-bold text-[56px] leading-none text-sd-ink">
+            DRAFT MANAGEMENT
+          </h1>
+          <Link
+            href="/admin/drafts/new"
+            className="bg-sd-red text-white font-oswald font-medium tracking-wide uppercase px-5 py-3 hover:bg-sd-red/90 transition-colors"
+          >
+            + Create New Draft
+          </Link>
+        </div>
+
+        <AdminCard title="Active & Paused Drafts">
+          {displayDrafts.length === 0 ? (
+            <p className="text-sd-ink/50 text-sm font-mono">No drafts found.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-sd-ink/10">
+                    {["Title", "Type", "Series", "Status", ""].map((col) => (
+                      <th
+                        key={col}
+                        className="text-left font-mono text-[11px] tracking-widest uppercase text-sd-ink/50 pb-3 pr-4"
+                      >
+                        {col}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {displayDrafts.map((d) => (
+                    <tr
+                      key={d.publicId}
+                      className="border-b border-sd-ink/5 hover:bg-sd-paper/60 transition-colors"
+                    >
+                      <td className="py-3 pr-4 font-medium text-sd-ink">{d.title}</td>
+                      <td className="py-3 pr-4 text-sd-ink/70">
+                        {d.draftType !== undefined ? String(d.draftType) : "—"}
+                      </td>
+                      <td className="py-3 pr-4 text-sd-ink/70">{d.seriesName ?? "—"}</td>
+                      <td className="py-3 pr-4">
+                        <span
+                          className={`inline-block px-2 py-0.5 text-[11px] font-mono tracking-wide uppercase rounded ${
+                            d.draftStatus === 2
+                              ? "bg-green-100 text-green-800"
+                              : d.draftStatus === 3
+                              ? "bg-yellow-100 text-yellow-800"
+                              : "bg-gray-100 text-gray-600"
+                          }`}
+                        >
+                          {STATUS_LABELS[d.draftStatus ?? -1] ?? "Unknown"}
+                        </span>
+                      </td>
+                      <td className="py-3 text-right">
+                        <Link
+                          href={`/admin/drafts/${d.publicId}/edit`}
+                          className="text-sd-blue text-sm font-medium hover:underline"
+                        >
+                          Edit
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </AdminCard>
+      </div>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/screendrafts.ui/src/components/layout/header/avatar-dropdown.tsx
+++ b/src/screendrafts.ui/src/components/layout/header/avatar-dropdown.tsx
@@ -3,6 +3,7 @@ import SignOutButton from "./sign-out-button";
 
 interface Props {
   name?: string | null;
+  isAdmin?: boolean;
 }
 
 function initials(name?: string | null): string {
@@ -15,7 +16,7 @@ function initials(name?: string | null): string {
     .toUpperCase();
 }
 
-export default function AvatarDropdown({ name }: Props) {
+export default function AvatarDropdown({ name, isAdmin }: Props) {
   return (
     <details className="relative" suppressHydrationWarning>
       <summary className="list-none cursor-pointer">
@@ -37,6 +38,17 @@ export default function AvatarDropdown({ name }: Props) {
         >
           My Draft Boards
         </Link>
+        {isAdmin && (
+          <>
+            <div className="border-t border-gray-100 mt-1 pt-1" />
+            <Link
+              href="/admin/drafts"
+              className="block px-4 py-2 text-sm text-sd-red font-medium hover:bg-gray-50 transition-colors"
+            >
+              Draft Management
+            </Link>
+          </>
+        )}
         <div className="border-t border-gray-100 mt-1 pt-1">
           <SignOutButton />
         </div>

--- a/src/screendrafts.ui/src/components/layout/header/site-header.tsx
+++ b/src/screendrafts.ui/src/components/layout/header/site-header.tsx
@@ -64,7 +64,7 @@ export default async function SiteHeader({ activePath }: { activePath?: string }
         )}
 
         {session ? (
-          <AvatarDropdown name={session.user?.name} />
+          <AvatarDropdown name={session.user?.name} isAdmin={isAdmin} />
         ) : (
           <>
             <SignInButton />

--- a/src/screendrafts.ui/src/services/admin/fetch-admin-drafts.ts
+++ b/src/screendrafts.ui/src/services/admin/fetch-admin-drafts.ts
@@ -1,0 +1,300 @@
+import { env } from "@/lib/env";
+import {
+  CampaignResponse,
+  CategoryResponse,
+  CreatedResponse,
+  SearchDraftsResponse,
+  SeriesResponse,
+  SmartEnumResponse,
+} from "@/lib/dto";
+
+// TODO: regenerate dto.ts after backend adds these response shapes if they differ
+export interface AdminDraftListItem extends SearchDraftsResponse {}
+
+export interface AdminSeriesOption {
+  publicId: string;
+  name: string;
+  allowedDraftTypes: SmartEnumResponse[];
+  defaultDraftType?: SmartEnumResponse;
+}
+
+export interface AdminHostOption {
+  publicId: string;
+  displayName: string;
+}
+
+export interface AdminDrafterOption {
+  publicId: string; // drafterId
+  displayName: string;
+}
+
+const apiBase = env.apiUrl;
+
+function authHeaders(accessToken: string | undefined): HeadersInit {
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+}
+
+export async function listAdminDrafts(
+  accessToken: string | undefined,
+  page = 1,
+  pageSize = 50
+): Promise<AdminDraftListItem[]> {
+  try {
+    const url = new URL(`${apiBase}/drafts/search`);
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("pageSize", String(pageSize));
+    const response = await fetch(url.toString(), {
+      headers: authHeaders(accessToken),
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json() as { items?: AdminDraftListItem[] };
+    return data.items ?? [];
+  } catch (err) {
+    console.error("[listAdminDrafts]", err);
+    return [];
+  }
+}
+
+export async function listAllSeries(
+  accessToken: string | undefined
+): Promise<AdminSeriesOption[]> {
+  try {
+    const response = await fetch(`${apiBase}/series`, {
+      headers: authHeaders(accessToken),
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json() as { items?: SeriesResponse[] };
+    return (data.items ?? []).map((s) => ({
+      publicId: s.publicId ?? "",
+      name: s.name ?? "",
+      allowedDraftTypes: s.allowedDraftTypes ?? [],
+      defaultDraftType: s.defaultDraftType,
+    }));
+  } catch (err) {
+    console.error("[listAllSeries]", err);
+    return [];
+  }
+}
+
+export async function searchAllHosts(
+  accessToken: string | undefined
+): Promise<AdminHostOption[]> {
+  try {
+    const response = await fetch(`${apiBase}/hosts/search`, {
+      method: "POST",
+      headers: {
+        ...authHeaders(accessToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ page: 1, pageSize: 200 }),
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json() as { items?: { publicId: string; displayName?: string; firstName?: string; lastName?: string }[] };
+    return (data.items ?? []).map((h) => ({
+      publicId: h.publicId,
+      displayName: h.displayName ?? `${h.firstName ?? ""} ${h.lastName ?? ""}`.trim(),
+    }));
+  } catch (err) {
+    console.error("[searchAllHosts]", err);
+    return [];
+  }
+}
+
+export async function listAllDrafters(
+  accessToken: string | undefined
+): Promise<AdminDrafterOption[]> {
+  try {
+    const response = await fetch(`${apiBase}/drafters`, {
+      method: "POST",
+      headers: {
+        ...authHeaders(accessToken),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ page: 1, pageSize: 200, retired: "false" }),
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json() as { drafters?: { items?: { drafterId: string; displayName: string }[] } };
+    return (data.drafters?.items ?? []).map((d) => ({
+      publicId: d.drafterId,
+      displayName: d.displayName,
+    }));
+  } catch (err) {
+    console.error("[listAllDrafters]", err);
+    return [];
+  }
+}
+
+export async function listAllCategories(
+  accessToken: string | undefined
+): Promise<CategoryResponse[]> {
+  try {
+    const response = await fetch(`${apiBase}/categories`, {
+      headers: authHeaders(accessToken),
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json() as { items?: CategoryResponse[] };
+    return (data.items ?? []).filter((c) => !c.isDeleted);
+  } catch (err) {
+    console.error("[listAllCategories]", err);
+    return [];
+  }
+}
+
+export async function listAllCampaigns(
+  accessToken: string | undefined
+): Promise<CampaignResponse[]> {
+  try {
+    const response = await fetch(`${apiBase}/campaigns`, {
+      headers: authHeaders(accessToken),
+      cache: "no-store",
+    });
+    if (!response.ok) return [];
+    const data = await response.json() as { items?: CampaignResponse[] };
+    return (data.items ?? []).filter((c) => !c.isDeleted);
+  } catch (err) {
+    console.error("[listAllCampaigns]", err);
+    return [];
+  }
+}
+
+// ── Mutation helpers (used in 'use client' form via server action or direct fetch) ──
+
+export async function createDraft(
+  accessToken: string,
+  body: { title: string; draftType: number; seriesId: string }
+): Promise<CreatedResponse> {
+  const response = await fetch(`${apiBase}/drafts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`POST /drafts failed (${response.status}): ${text}`);
+  }
+  return response.json() as Promise<CreatedResponse>;
+}
+
+export async function createDraftPart(
+  accessToken: string,
+  draftPublicId: string,
+  body: { publicId: string; partIndex: number; minimumPosition: number; maximumPosition: number }
+): Promise<string> {
+  const response = await fetch(`${apiBase}/drafts/${encodeURIComponent(draftPublicId)}/parts`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`POST /drafts/${draftPublicId}/parts failed (${response.status}): ${text}`);
+  }
+  // Returns the new part publicId as a JSON string
+  const raw = await response.text();
+  try { return JSON.parse(raw) as string; } catch { return raw; }
+}
+
+export async function addHostToDraftPart(
+  accessToken: string,
+  draftPartId: string,
+  body: { draftPartId: string; hostPublicId: string; hostRole: number }
+): Promise<void> {
+  const response = await fetch(
+    `${apiBase}/draft-parts/${encodeURIComponent(draftPartId)}/hosts`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`POST /draft-parts/${draftPartId}/hosts failed (${response.status}): ${text}`);
+  }
+}
+
+export async function addParticipantToDraftPart(
+  accessToken: string,
+  draftPartId: string,
+  body: { draftPartId: string; participantPublicId: string; participantKind: number }
+): Promise<void> {
+  const response = await fetch(
+    `${apiBase}/draft-parts/${encodeURIComponent(draftPartId)}/participants`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(
+      `POST /draft-parts/${draftPartId}/participants failed (${response.status}): ${text}`
+    );
+  }
+}
+
+export async function setDraftCategories(
+  accessToken: string,
+  draftPublicId: string,
+  categoryIds: string[]
+): Promise<void> {
+  const response = await fetch(
+    `${apiBase}/drafts/${encodeURIComponent(draftPublicId)}/categories`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ publicId: draftPublicId, categoryIds }),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(
+      `PUT /drafts/${draftPublicId}/categories failed (${response.status}): ${text}`
+    );
+  }
+}
+
+export async function setDraftCampaign(
+  accessToken: string,
+  draftPublicId: string,
+  campaignId: string
+): Promise<void> {
+  const response = await fetch(
+    `${apiBase}/drafts/${encodeURIComponent(draftPublicId)}/campaign`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ publicId: draftPublicId, campaignId }),
+    }
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(
+      `POST /drafts/${draftPublicId}/campaign failed (${response.status}): ${text}`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **Draft Management** entry to the user avatar dropdown, gated to `Administrator`/`SuperAdministrator` roles
- New `/admin/drafts` index page listing Active and Paused drafts in a table with an Edit action
- New `/admin/drafts/new` create form — single scrollable page with 6 sections
- Placeholder `/admin/drafts/[draftId]/edit` page (TODO: implement)
- Service layer `fetch-admin-drafts.ts` with read fetchers (series, hosts, drafters, categories, campaigns, draft list) and mutation helpers for the sequential create flow

## Create Draft form sections

1. **Core metadata** — Title (required), Series (required, populates draft type dropdown from `series.allowedDraftTypes`), Draft Type (required)
2. **Parts configuration** — Number of parts input; per-part collapsible cards with min/max positions. Standard and SpeedDraft lock max at 7; all other types are user-editable
3. **Hosts** (optional) — searchable list; each selected host gets a Primary / Co-Host radio toggle
4. **Participants** (optional) — searchable checkbox list of drafters
5. **Category** (optional) — multi-select checkbox grid
6. **Campaign** (optional) — single-select dropdown

## API submit sequence

On submit the form fires these calls in order (each step depends on IDs returned by the previous):

1. `POST /drafts` → draftPublicId
2. `POST /drafts/{draftId}/parts` × numParts → partPublicIds
3. `POST /draft-parts/{partId}/hosts` for each host × part
4. `POST /draft-parts/{partId}/participants` for each drafter × part
5. `PUT /drafts/{draftId}/categories` (if any selected)
6. `POST /drafts/{draftId}/campaign` (if selected)

Errors surface inline; the submit button stays disabled/loading throughout the sequence. On success, redirects to `/admin/drafts` (TODO: redirect to edit page once it exists).

## Reviewer notes

- No local TypeScript interfaces duplicate dto.ts types — all imported from `@/lib/dto`
- Pre-existing TypeScript errors in `dto.ts` are unrelated to this PR (NSwag generation quirks)
- The draft type dropdown is populated dynamically from `series.allowedDraftTypes` returned by `GET /series`, so no hardcoded enum-to-value mappings are needed in the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)